### PR TITLE
Clubs API の破壊的な変更に対応: stage -> status

### DIFF
--- a/get_data_from_earth.rb
+++ b/get_data_from_earth.rb
@@ -37,7 +37,7 @@ def get_query_from_template(filter)
         latitude
         longitude
         countryCode
-        stage
+        status
         urlSlug: url
         id: uuid
         #startTime

--- a/upsert_dojos_geojson.rb
+++ b/upsert_dojos_geojson.rb
@@ -68,19 +68,23 @@ dojos_earth.each do |dojo|
   if dojo[:latitude] && dojo[:longitude]
     #pp dojo
 
-    # 以下の stage ステータスを見て活動中ではない道場は除外
+    # NOTE: 2025/03/29 に Clubs API は予告なく破壊的な変更がされた
+    # https://github.com/coderdojo-japan/map.coderdojo.jp/pull/19
+
+    # 以下の status ステータスを見て活動中ではない道場は除外
     #
-    # stage:              => Clubs API (renewal in 2023/12)
-    # 0: In planning      => PENDING
-    # 1: Open, come along => OPEN
-    # 2: Register ahead   => REGISTER
-    # 3: 満員             => FULL
+    # status:             => Clubs API (as of 2025/03/29)
+    # 0: In planning      => PLANNING         (formerly PENDING)
+    # 1: Open, come along => RUNNING_SESSIONS (formerly OPEN)
+    # 2: Register ahead   => RUNNING_SESSIONS (formerly REGISTER)
+    # 3: 満員             => RUNNING_SESSIONS (formerly FULL)
     # 4: 活動していません => ??? (Maybe deleted or PENDING?)
     # Clubs API https://clubs-api.raspberrypi.org/
+    # ChatGPT Log: https://chatgpt.com/share/67ecfb6a-26f4-800a-9c79-c3c54d91e829
     #
     # MEMO: Clubs API (旧: Zen API) リニューアル前は下記コードが使えた
-    #       if dojo[:geoPoint] && dojo[:country] && dojo[:stage] != 4
-    next unless ['OPEN', 'REGISTER', 'FULL'].include? dojo[:stage]
+    #       if dojo[:geoPoint] && dojo[:country] && dojo[:status] != 4
+    next unless ['PLANNING', 'RUNNING_SESSIONS'].include? dojo[:status]
 
     # アクティブで、地域情報が日本 (JP) の場合、地図上への配置処理に進む
     if dojo[:countryCode] == "JP"


### PR DESCRIPTION
## 起こったこと

2025/03/29 に Clubs API は (また) 予告なく破壊的な変更がされた 😱 💦 

📝 _財団が予告なく破壊的な変更を加えるのは過去に複数回あったことから、データは事前にキャッシュ化されています。このため [🗺️ DojoMap](https://map.coderdojo.jp/) のユーザーにはほとんど影響はなく、今後も緊急で対応する必要はない仕組みになっています。(厳密には「次回開催日」の更新がされない部分のみ影響がありますが、数週間週間〜数ヶ月程度先のデータであるため十分に余裕を持って対応できます)_

```
Run bundle exec rake get_data_from_earth
/opt/hostedtoolcache/Ruby/3.4.1/x64/bin/ruby get_data_from_earth.rb
 JP_DOJOS_QUERY: 1..Error: {errors: [{message: "Field 'stage' doesn't exist on type 'Club'", locations: [{line: 20, column: 7}], path: ["query", "clubs", "nodes", "stage"], extensions: {code: "undefinedField", typeName: "Club", fieldName: "stage"}}]}
 (JP: 0)
ALL_DOJOS_QUERY: 1..Error: {errors: [{message: "Field 'stage' doesn't exist on type 'Club'", locations: [{line: 20, column: 7}], path: ["query", "clubs", "nodes", "stage"], extensions: {code: "undefinedField", typeName: "Club", fieldName: "stage"}}]}
 (Total: 0)

Fetched number of dojos: 0

Check out its details by:
$ cat dojos_earth.json

ERROR: NUMBER_OF_DOJOS=0
This number should be 1000+. Something went wrong.
Error: Process completed with exit code 1.
```

![image](https://github.com/user-attachments/assets/5010a5d6-dd35-4f78-84b3-17135dc89a85)


## 本 PR でやること

- [x] 破壊的に変更された箇所を見つける: f092dec
- [x] 破壊的に変更された箇所に対応する: b38799b
- [x] マージ後、CI でデータが最新に更新されることを確認する 
   - https://github.com/coderdojo-japan/map.coderdojo.jp/commit/ba13a45ea74564fdeabb670793b7094ea6252812
   - https://github.com/coderdojo-japan/map.coderdojo.jp/actions/runs/14215685314/job/39831779646

📸 スクショ (Actions のログは一定期間後に削除されるため)

<img width="833" alt="image" src="https://github.com/user-attachments/assets/2e16f800-25e0-426e-aa9e-30203a6af10f" />


