### PR TITLE
名寄せデータ比較用の一時エンドポイントを追加

### DIFF
--- a/_data/dojo2dojo.json
+++ b/_data/dojo2dojo.json
@@ -1,0 +1,1514 @@
+[
+  {
+    "id": "014a81c0-515a-4a9d-b71b-469fb72253df",
+    "name_japan": "赤羽",
+    "name_earth": "Akabane, Tokyo",
+    "countryCode": "JP",
+    "urlSlug": "jp/kita-tokyo/akabane-tokyo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "01df8836-8a93-4e6d-9f49-594b461e500b",
+    "name_japan": "小田原",
+    "name_earth": " CoderDojo 小田原",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "054617de-6f0a-4cb8-804c-f9b1ef95d3ea",
+    "name_japan": "吉備",
+    "name_earth": "Kibi, Okayama",
+    "countryCode": "JP",
+    "urlSlug": "jp/okayama-okayama-prefecture/kibi-okayama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "054e135a-c8f1-4f57-ba2e-1be96a5ae49c",
+    "name_japan": "八尾",
+    "name_earth": "八尾@yotteco",
+    "countryCode": "JP",
+    "urlSlug": "jp/yao-osaka/ba1-wei3-yotteco",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "05886113-3319-4a05-a79d-ac249cd00e9e",
+    "name_japan": "仙台若林",
+    "name_earth": "仙台若林 (SendaiWakabayashi)",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "08b15c21-cbb4-4939-958a-59774c5a60eb",
+    "name_japan": "滑川",
+    "name_earth": "滑川",
+    "countryCode": "JP",
+    "urlSlug": "jp/namerikawa-toyama/hua2-chuan1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "09718f70-1a91-41de-bea3-a5d09ef099c4",
+    "name_japan": "札幌",
+    "name_earth": "Sapporo",
+    "countryCode": "JP",
+    "urlSlug": "jp/sapporo-hokkaido-prefecture/sapporo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "09a8ed76-403b-4833-b254-f7da95831b0a",
+    "name_japan": "津和野",
+    "name_earth": "津和野",
+    "countryCode": "JP",
+    "urlSlug": "jp/dao3-gen1-xian4-lu4-zu2-jun4/jin1-he2-ye3",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "0a7bb96c-9cd6-4d96-b052-096186a0e012",
+    "name_japan": "名護",
+    "name_earth": "Nago",
+    "countryCode": "JP",
+    "urlSlug": "jp/nago-okinawa-prefecture/nago",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "0b208aca-b939-4ad0-b2ef-286dacd9fc19",
+    "name_japan": "舟橋",
+    "name_earth": "舟橋",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-toyama/zhou1-qiao2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "0c422d07-3cd2-4cdb-a8fe-a54eec5c3605",
+    "name_japan": "大田・邑南、他",
+    "name_earth": "Shimane @ Gotsu",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan/shimane-gotsu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "0dc27210-c03a-4c3e-a819-0b5266a51654",
+    "name_japan": "奈良",
+    "name_earth": "Nara, Nara",
+    "countryCode": "JP",
+    "urlSlug": "jp/nara-ken/nara-nara-prefecture/nara-nara",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "0f582494-c6ad-4b88-ad8a-dc18567a825e",
+    "name_japan": "成田",
+    "name_earth": "Narita",
+    "countryCode": "JP",
+    "urlSlug": "jp/narita-chiba-prefecture/narita",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "116f95d3-ba16-4c89-bb3c-3ef37994d39f",
+    "name_japan": "村山",
+    "name_earth": "Murayama",
+    "countryCode": "JP",
+    "urlSlug": "jp/murayama-yamagata/murayama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "1237536f-44cf-44a7-8fb6-464fb12f3865",
+    "name_japan": "神楽坂",
+    "name_earth": "CoderDojo Kagurazaka",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "13edfe3d-53f3-486b-a4c7-835b294f52e4",
+    "name_japan": "春日",
+    "name_earth": "Kasuga@春日市ふれあい文化センター",
+    "countryCode": "JP",
+    "urlSlug": "jp/kasuga-fukuoka/kasugafureaisent",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "141b1722-5423-41e3-ac16-ab46c5c82dc0",
+    "name_japan": "瑞穂",
+    "name_earth": "瑞穂",
+    "countryCode": "JP",
+    "urlSlug": "jp/ming2-gu3-wu1-shi4-rui4-sui4-qu1-zuo3-du4-ting3-4-ding1-mu4-9-fan1-di4/rui4-sui4",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "14bf5604-1ca8-4d10-8187-b33fb5c2443f",
+    "name_japan": "京都四条",
+    "name_earth": "KyotoShijo",
+    "countryCode": "JP",
+    "urlSlug": "jp/kyoto/kyotoshijo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "14ced3ef-6b38-4ba1-9be5-112c834c0bf9",
+    "name_japan": "大府",
+    "name_earth": "大府",
+    "countryCode": "JP",
+    "urlSlug": "jp/obu-aichi/da4-fu3",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "15f4c828-2c65-4c86-a6e2-67cd9659b45d",
+    "name_japan": "紙屋町",
+    "name_earth": "Kamiyacho",
+    "countryCode": "JP",
+    "urlSlug": "jp/hiroshima-hiroshima-prefecture/kamiyacho",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "16037357-c116-4d42-a580-6c0011d7da52",
+    "name_japan": "淡路島",
+    "name_earth": "Awajishima,Hyogo",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-hy-go-prefecture/awajishima-hyogo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "16609fdd-0d89-4c23-8d55-fe7f01416417",
+    "name_japan": "つくば",
+    "name_earth": "Tsukuba, Ibrakaki",
+    "countryCode": "JP",
+    "urlSlug": "jp/tsukuba-ibaraki-prefecture/tsukuba-ibrakaki",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "18704b53-1042-4464-9d49-8820c6ff8c97",
+    "name_japan": "黒潮町",
+    "name_earth": "黒潮町",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "193e95b4-c71f-43cf-a663-7a5dc179beb8",
+    "name_japan": "岐阜",
+    "name_earth": "Gifu",
+    "countryCode": "JP",
+    "urlSlug": "jp/gifu-gifu-prefecture/gifu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "19ae9948-e778-49b9-bbd7-ef3d895518f9",
+    "name_japan": "鎌ケ谷",
+    "name_earth": "Kamagaya, Chiba",
+    "countryCode": "JP",
+    "urlSlug": "jp/qian1-ye4-xian4/kamagaya-chiba",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "1c8ab0f9-e1ab-4874-b364-d620a84ea0dc",
+    "name_japan": "立川",
+    "name_earth": "立川",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-dong1-jing1-du1-li4-chuan1-shi4/li4-chuan1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "1d5eaad4-447f-4397-b80b-356a76c4146b",
+    "name_japan": "市川",
+    "name_earth": "Ichikawa,Chiba",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-qian1-ye4-xian4-shi4-chuan1-shi4/ichikawa-chiba",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "1e10bdbc-8d55-438b-8714-380b073378b9",
+    "name_japan": "西宮・梅田",
+    "name_earth": "Umeda, Osaka, @ Cybozu",
+    "countryCode": "JP",
+    "urlSlug": "jp/saka-fu/osaka-osaka-prefecture/umeda-osaka-cybozu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "1e2e7ad6-06b7-46bc-adfe-28c616826d86",
+    "name_japan": "岸和田",
+    "name_earth": "Kishiwada, Osaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/kishiwada-osaka/kishiwada-osaka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "1edba530-593e-454c-aaec-1a591193a876",
+    "name_japan": "富田林",
+    "name_earth": "Tondabayashi, Osaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/tondabayashi-osaka-prefecture/tondabayashi-osaka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "23eb0988-9d02-48ce-90dd-1b471a9f7556",
+    "name_japan": "厚木",
+    "name_earth": "Atsugi, Kanagawa",
+    "countryCode": "JP",
+    "urlSlug": "jp/naka-machi-atsugi-shi-kanagawa-prefecture/atsugi-kanagawa",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "288a173c-626f-4079-b5e3-3d09ef17764f",
+    "name_japan": "ほんごう",
+    "name_earth": "Hongo",
+    "countryCode": "JP",
+    "urlSlug": "jp/bunkyo-tokyo/hongo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "28f70fe5-4f18-45e5-8fbc-7718bfd4415b",
+    "name_japan": "とよなか",
+    "name_earth": "Toyonaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/toyonaka-osaka-prefecture/toyonaka-1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "29b2f7f6-b147-4650-9e9c-d5bb49bf5922",
+    "name_japan": "浦添",
+    "name_earth": "浦添（沖縄）",
+    "countryCode": "JP",
+    "urlSlug": "jp/urasoe-okinawa-prefecture/pu3-tian1-chong1-sheng2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "2b19b06b-d9f1-4594-94d6-f2b40d4c1371",
+    "name_japan": "生駒",
+    "name_earth": "Ikoma, Nara",
+    "countryCode": "JP",
+    "urlSlug": "jp/ikoma-nara-prefecture/ikoma-nara",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "2bb8fdc7-3fdf-4287-a2af-be967439e4e8",
+    "name_japan": "日野",
+    "name_earth": "日野",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "2fbba227-6a47-4d61-86df-62f059df6da2",
+    "name_japan": "江別",
+    "name_earth": "Ebetsu, Hokkaido",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan/ebetsu-hokkaido",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "31f9b905-27c3-4fce-b047-ca958acb62ad",
+    "name_japan": "狛江",
+    "name_earth": "CoderDojo Komae",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "327a7fd8-a875-4504-b294-59875e1c9e0b",
+    "name_japan": "ももち",
+    "name_earth": "Momochi",
+    "countryCode": "JP",
+    "urlSlug": "jp/fukuoka-fukuoka-prefecture/momochi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "32b5a941-46ce-4d8d-ace0-6bfb0e113adb",
+    "name_japan": "さいたま",
+    "name_earth": "Saitama",
+    "countryCode": "JP",
+    "urlSlug": "jp/1-5-miyamachi-oomiya-ku-saitama-shi-saitama/saitama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "35341a53-ce39-450e-a56d-27a5607e24dd",
+    "name_japan": "伊予",
+    "name_earth": "Iyo, Ehime",
+    "countryCode": "JP",
+    "urlSlug": "jp/iyo-ehime/iyo-ehime",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "35c73302-7e19-47a8-9dca-4a5340a10749",
+    "name_japan": "麹町@アドバンスト・ソフト",
+    "name_earth": "麹町@アドバンスト・ソフト",
+    "countryCode": "JP",
+    "urlSlug": "jp/chiyoda-tokyo/adobansutosofuto",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "36a062a1-1a8c-4e04-aec1-c06308b1440e",
+    "name_japan": "静岡",
+    "name_earth": "Shizuoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/shizuoka-shizuoka-prefecture/shizuoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "373cd200-f8b3-49fd-bbcd-ff72186a5e18",
+    "name_japan": "さが",
+    "name_earth": "Coderdojo Saga",
+    "countryCode": "JP",
+    "urlSlug": "jp/saga/saga",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "3812509c-ead6-43b0-810f-e1ad4773bdeb",
+    "name_japan": "松山",
+    "name_earth": "CoderDojoMatsuyama",
+    "countryCode": "JP",
+    "urlSlug": "jp/matsuyama-ehime/coderdojomatsuyama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "38abd14d-2633-4690-9bf4-601d86a8bfa9",
+    "name_japan": "早良",
+    "name_earth": "早良",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "3a1ef147-d9e7-4398-8c36-7ddf7036e343",
+    "name_japan": "前橋",
+    "name_earth": "Maebashi, Gunma",
+    "countryCode": "JP",
+    "urlSlug": "jp/maebashi-gunma-prefecture/maebashi-gunma",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "3b543ede-20e5-4283-a0a6-c342fcb3ffc8",
+    "name_japan": "新発田",
+    "name_earth": "Shibata@TINKERKIDS",
+    "countryCode": "JP",
+    "urlSlug": "jp/shibata-niigata-prefecture/shibata-tinkerkids",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "3d037ab0-1ba5-4c94-97ef-2898a37bdb68",
+    "name_japan": "多摩センター",
+    "name_earth": "Tama Center @ Tokyo",
+    "countryCode": "JP",
+    "urlSlug": "jp/tama-tokyo/tama-center-tokyo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "3d1dc877-932f-4e0d-a160-7ef254e5dbd7",
+    "name_japan": "吹田",
+    "name_earth": "Suita, Osaka @ 6Vox",
+    "countryCode": "JP",
+    "urlSlug": "jp/suita-osaka-prefecture/suita-osaka-6vox",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "3ebac46c-b078-4322-b74a-89ddb7aa9c3e",
+    "name_japan": "藤井寺・柏原",
+    "name_earth": "Fujiidera",
+    "countryCode": "JP",
+    "urlSlug": "jp/fujiidera-osaka/fujiidera",
+    "status": "PLANNING"
+  },
+  {
+    "id": "3ff02374-2857-4a61-9df2-325fa13c020f",
+    "name_japan": "加西",
+    "name_earth": "加西",
+    "countryCode": "JP",
+    "urlSlug": "jp/kasai-hyogo/jia1-xi1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4189b559-90c7-45ce-9f23-8df62e8b331a",
+    "name_japan": "磐田",
+    "name_earth": "磐田",
+    "countryCode": "JP",
+    "urlSlug": "jp/iwata-shizuoka/pan2-tian2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "426b6d19-e524-40c0-b898-ab0240c61de3",
+    "name_japan": "富山",
+    "name_earth": "富山@長江",
+    "countryCode": "JP",
+    "urlSlug": "jp/toyama/fu4-shan1-chang2-jiang1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "43574426-3330-48b6-bba9-1a7f85e89f3e",
+    "name_japan": "灘",
+    "name_earth": "Nada, Hyogo",
+    "countryCode": "JP",
+    "urlSlug": "jp/higashinada-ward-hy-go-prefecture/nada-hyogo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "46a7f225-d92b-49a3-b70e-652fa51bc23d",
+    "name_japan": "流山",
+    "name_earth": "Nagareyama",
+    "countryCode": "JP",
+    "urlSlug": "jp/nagareyama-chiba-prefecture/nagareyama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "48dad885-33d5-441d-960e-d5cb860ccbb8",
+    "name_japan": "戸田公園",
+    "name_earth": "戸田公園",
+    "countryCode": "JP",
+    "urlSlug": "jp/toda-saitama/hu4-tian2-gong1-yuan2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4a2185e1-79ff-4b1c-a17b-9e66792036a1",
+    "name_japan": "青山",
+    "name_earth": "Aoyama",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4d6fb9e4-831c-48f0-9ba3-4d8fcd64ca36",
+    "name_japan": "池田石橋",
+    "name_earth": "Ishibashi, Ikeda @ Shoufukuji",
+    "countryCode": "JP",
+    "urlSlug": "jp/ikeda-osaka/ishibashi-ikeda-shoufukuji",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4d7fe211-4b93-4e9a-98a6-9e4ac9ccf944",
+    "name_japan": "新代田",
+    "name_earth": "Shindaita",
+    "countryCode": "JP",
+    "urlSlug": "jp/setagaya-tokyo/shindaita",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4dd95628-213e-4127-a370-687fac33e94d",
+    "name_japan": "池袋",
+    "name_earth": "Ikebukuro,Tokyo @ Unique-inet",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-dong1-jing1-du1-li3-dao3-qu1/ikebukuro-tokyo-unique-inet",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4f1bc4c3-4bde-47f7-9d84-b8c0038f8c06",
+    "name_japan": "滝沢",
+    "name_earth": "Takizawa,Iwate@codeMo",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-yan2-shou3-xian4-long2-ze2-shi4/takizawa-iwate-codemo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "4fc8ca2d-3786-4194-a07c-7ab2be3579f2",
+    "name_japan": "船橋",
+    "name_earth": "funabashi",
+    "countryCode": "JP",
+    "urlSlug": "jp/funabashi-chiba-prefecture/funabashi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "521e293f-abb9-4750-b5bd-275a4367fd08",
+    "name_japan": "日進",
+    "name_earth": "日進",
+    "countryCode": "JP",
+    "urlSlug": "jp/nisshin-aichi-prefecture/ri4-jin4",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "53703176-6fa2-40b8-b796-e97aa73de1bb",
+    "name_japan": "久留米",
+    "name_earth": "Kurume",
+    "countryCode": "JP",
+    "urlSlug": "jp/kurume-fukuoka-prefecture/kurume",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "53fdf401-51bd-401c-8260-4632e89326c8",
+    "name_japan": "武蔵小杉",
+    "name_earth": "MusashiKosugi",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-kanagawa/musashikosugi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "542b0936-d7f7-49ef-9675-e352c3e5281c",
+    "name_japan": "土気",
+    "name_earth": "土気",
+    "countryCode": "JP",
+    "urlSlug": "jp/chiba-chiba-prefecture/tu3-qi4",
+    "status": "PLANNING"
+  },
+  {
+    "id": "543b619c-b1a8-48f5-b5f0-f9fe5bd1bfb2",
+    "name_japan": "三好",
+    "name_earth": "Miyoshi, Tokushima @ Microsoft",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-de2-dao3-xian4-san1-hao3-shi4/miyoshi-tokushima-microsoft",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "54fb4603-de0d-4de1-9fd9-518c5127caaa",
+    "name_japan": "枚方",
+    "name_earth": "Hirakata, Osaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-da4-ban3-fu3-mei2-fang1-shi4/hirakata-osaka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "55f5d988-38b6-4ede-97d6-5da2a1d87ebb",
+    "name_japan": "せんなん",
+    "name_earth": "Sennan, Osaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/sennan-osaka-prefecture/sennan-osaka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "5652aca9-cdb6-4181-9569-48928e28e5ac",
+    "name_japan": "溝口",
+    "name_earth": "Mizonokuchi",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-kanagawa-prefecture/mizonokuchi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "569a61a2-f793-4921-961e-df92e9dde294",
+    "name_japan": "石垣",
+    "name_earth": "Ishigaki",
+    "countryCode": "JP",
+    "urlSlug": "jp/chong1-sheng2-xian4-shi2-yuan2-shi4-deng1-ye3-cheng2/ishigaki",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "57efa1ba-4c02-4e9e-8419-d47d2f3c32d6",
+    "name_japan": "野母崎",
+    "name_earth": "CoderDojo 野母崎（長崎）",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "5a299787-5fa0-42c3-a73d-63ea0e956c0f",
+    "name_japan": "新宿",
+    "name_earth": "新宿(Shinjuku) @ Okubo Regional Center",
+    "countryCode": "JP",
+    "urlSlug": "jp/shinjuku-tokyo/xin1-su4-shinjuku-okubo-regional-center",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "5b475bc8-cc83-4824-a0da-cd5000325eee",
+    "name_japan": "蒲田",
+    "name_earth": "蒲田@ユニークアイネット",
+    "countryCode": "JP",
+    "urlSlug": "jp/tokyo/yunkuainetto",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "5b77f3b2-0e07-4884-8242-691f7acf5b44",
+    "name_japan": "堺",
+    "name_earth": "Sakai, Osaka @ Pangea Café",
+    "countryCode": "JP",
+    "urlSlug": "jp/sakai-osaka-prefecture/sakai-osaka-pangea-cafe",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "5f1057ff-473d-4380-8e1c-5b4d46ab7bd3",
+    "name_japan": "大府共和",
+    "name_earth": "大府共和",
+    "countryCode": "JP",
+    "urlSlug": "jp/da4-fu3-gong4-he2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "618fbd6c-540e-4192-b9b6-45de228f3318",
+    "name_japan": "伊勢原",
+    "name_earth": "Isehara @ Civic Support Center",
+    "countryCode": "JP",
+    "urlSlug": "jp/isehara-kanagawa/isehara-civic-support-center",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "6241b746-c101-43b4-ac7d-e0319f43a5dc",
+    "name_japan": "となみ",
+    "name_earth": "となみ",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-toyama/tonami",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "65d4e363-dec4-490c-ae97-c2018f844422",
+    "name_japan": "木更津",
+    "name_earth": "木更津",
+    "countryCode": "JP",
+    "urlSlug": "jp/qian1-ye4-xian4/mu4-geng1-jin1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "662f23bc-e2c7-4365-a3be-d7f29c1156b9",
+    "name_japan": "天白",
+    "name_earth": "天白,名古屋,愛知",
+    "countryCode": "JP",
+    "urlSlug": "jp/aichi-ken/ai4-zhi1-xian4-ming2-gu3-wu1-shi4-tian1-bai2-qu1-yuan2-ding1-mu4/tian1-bai2-ming2-gu3-wu1-ai4-zhi1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "67cbaaab-e71e-4f98-aefc-6dc62d5ef197",
+    "name_japan": "宇治",
+    "name_earth": "Uji, Kyoto",
+    "countryCode": "JP",
+    "urlSlug": "jp/uji-kyoto/uji-kyoto",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "6bf2fa03-261c-4326-bfe2-da91b6824399",
+    "name_japan": "稲毛海岸",
+    "name_earth": "inagekaigan",
+    "countryCode": "JP",
+    "urlSlug": "jp/chiba-chiba/inagekaigan",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "6cd39679-f6e9-4d01-8b9c-d77c844e13e0",
+    "name_japan": "飯田",
+    "name_earth": "IIDA@logicaland",
+    "countryCode": "JP",
+    "urlSlug": "jp/iida-nagano/iida-logicaland",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "700c3760-6d11-44d8-8d36-c501e03c028f",
+    "name_japan": "磐梯",
+    "name_earth": "BANDAI@BandaiCommunityCenter",
+    "countryCode": "JP",
+    "urlSlug": "jp/bandai-fukushima/bandai-bandaicommunitycenter",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "71008d87-7849-4be0-8868-578642d24718",
+    "name_japan": "大阪狭山",
+    "name_earth": "Osakasayama, Osaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/osakasayama-osaka-prefecture/osakasayama-osaka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "71c8496c-c24d-4ea9-b6aa-b65585c531ba",
+    "name_japan": "徳島",
+    "name_earth": "Tokushima @ Tokushima University",
+    "countryCode": "JP",
+    "urlSlug": "jp/tokushima-tokushima-prefecture/tokushima-tokushima-university-1",
+    "status": "PLANNING"
+  },
+  {
+    "id": "71cf13bc-446f-482e-8581-3b50795d3528",
+    "name_japan": "白河",
+    "name_earth": "Shirakawa",
+    "countryCode": "JP",
+    "urlSlug": "jp/shirakawa-fukushima-prefecture/shirakawa",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "74c41f4f-2854-4c18-b81f-7f3ef9befcca",
+    "name_japan": "たまち",
+    "name_earth": "たまち",
+    "countryCode": "JP",
+    "urlSlug": "jp/minato-tokyo/tamachi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7767c56f-358e-4bb8-bd47-c9d326d4f7d4",
+    "name_japan": "稲沢正明寺",
+    "name_earth": "稲沢正明寺",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-aichi/dao4-ze2-zheng4-ming2-si4",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7c0ca939-b98e-4fa5-aa6c-dcdf2cffd280",
+    "name_japan": "浦和@Urawa Minecraft Club",
+    "name_earth": "Urawa @ Urawa Minecraft Club",
+    "countryCode": "JP",
+    "urlSlug": "jp/urawa-saitama/urawa-urawa-minecraft-club",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7c0e84fa-9e60-4190-829d-44af85c313d6",
+    "name_japan": "黒部",
+    "name_earth": "黒部",
+    "countryCode": "JP",
+    "urlSlug": "jp/kurobe-toyama/hei1-bu4",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7c909980-9cf5-4f27-a98d-1f4454519333",
+    "name_japan": "長野",
+    "name_earth": "長野",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7cf9aa56-37d2-4deb-8b75-29793ede6d3d",
+    "name_japan": "名古屋",
+    "name_earth": "Nagoya",
+    "countryCode": "JP",
+    "urlSlug": "jp/aichi-ken/nagoya-aichi-prefecture/nagoya",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7d105d74-f935-4648-b223-2a8452adcd26",
+    "name_japan": "松原",
+    "name_earth": "松原",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-osaka-prefecture/song1-yuan2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7dc24b24-8560-4b5e-92c1-031aa2fa13db",
+    "name_japan": "陸前高田",
+    "name_earth": "Rikuzentakata @ Iwate",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-iwate-prefecture/rikuzentakata-iwate",
+    "status": "PLANNING"
+  },
+  {
+    "id": "7ef14ebb-522a-4763-89b9-994f04219d51",
+    "name_japan": "大船",
+    "name_earth": "Ofuna",
+    "countryCode": "JP",
+    "urlSlug": "jp/kamakura-kanagawa-prefecture/ofuna",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "7ff3f2ee-0c75-4443-a9ac-d602618512af",
+    "name_japan": "西那須野",
+    "name_earth": "Nishinasuno@Minami comunity center",
+    "countryCode": "JP",
+    "urlSlug": "jp/nasushiobara-tochigi/nishinasuno-minami-comunity-center",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "818b53de-9308-47ef-9767-6da77a052074",
+    "name_japan": "塩尻",
+    "name_earth": "Shiojiri / 塩尻",
+    "countryCode": "JP",
+    "urlSlug": "jp/nagano-ken/shiojiri-nagano-prefecture/shiojiri-yan2-kao1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "831a556f-4f1a-49d4-bd2d-240e3378af1b",
+    "name_japan": "若葉若松",
+    "name_earth": "Wakaba Wakamatsu",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-qian1-ye4-xian4-chiba/wakaba-wakamatsu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "838ad4e4-bcd1-4f22-8ae4-742c22579103",
+    "name_japan": "猪名川",
+    "name_earth": "Inagawa, Hyogo",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan/inagawa-hyogo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "85796abb-f777-4edd-886d-af0345e8fde8",
+    "name_japan": "安城",
+    "name_earth": "Anjo",
+    "countryCode": "JP",
+    "urlSlug": "jp/anjo-aichi-prefecture/anjo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "859b0f40-230c-4a90-ad9f-4e536f33ff9a",
+    "name_japan": "三春",
+    "name_earth": "三春",
+    "countryCode": "JP",
+    "urlSlug": "jp/fu2-dao3-xian4-tian2-cun1-jun4/san1-chun1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "86794277-80b2-4add-9d48-dad501c81642",
+    "name_japan": "南風原",
+    "name_earth": "南風原 ",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "87acaba4-6eb9-4700-b652-e62928593578",
+    "name_japan": "喜多方",
+    "name_earth": "Kitakata",
+    "countryCode": "JP",
+    "urlSlug": "jp/kitakata-fukushima-prefecture/kitakata",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "8820005d-91ad-4db3-9f1b-3a32dec6c387",
+    "name_japan": "倉敷",
+    "name_earth": "Kurashiki, Okayama prefecture",
+    "countryCode": "JP",
+    "urlSlug": "jp/kurashiki-okayama-prefecture/kurashiki-okayama-prefecture",
+    "status": "PLANNING"
+  },
+  {
+    "id": "8e4a0410-56d9-4ded-bdd2-e4334dc94f2c",
+    "name_japan": "恩納@OIST",
+    "name_earth": "CoderDojo Onna @OIST",
+    "countryCode": "JP",
+    "urlSlug": "jp/nago-city-okinawa/yanbaru-okinawa-akemio-sky-dome",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "8fccc724-3930-4245-a96f-2f38650d8471",
+    "name_japan": "横浜師岡",
+    "name_earth": "Morooka, Yokohama @ Morooka Community House",
+    "countryCode": "JP",
+    "urlSlug": "jp/yokohama-kanagawa/morooka-yokohama-morooka-community-house",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "901f6e5c-f3de-4bb6-9279-825505872b41",
+    "name_japan": "宜野湾",
+    "name_earth": "Ginowan, Okinawa",
+    "countryCode": "JP",
+    "urlSlug": "jp/chong1-sheng2-xian4-pu3-tian1-shi4-zhong4-jian1-ding1-mu4/ginowan-okinawa",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "91e15c61-549a-486c-9827-178a324c689f",
+    "name_japan": "ひばりヶ丘",
+    "name_earth": "Hibarigaoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/saitama-ken/japan-saitama/hibarigaoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "94cc35b3-5efa-4835-8dd8-de3b5f534ead",
+    "name_japan": "犬山",
+    "name_earth": "犬山",
+    "countryCode": "JP",
+    "urlSlug": "jp/inuyama-aichi/quan3-shan1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "959721ca-a351-4263-bb85-1f430b04b093",
+    "name_japan": "長門",
+    "name_earth": "Nagato @ non profit organization TSUNAGU",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-yamaguchi/nagato-non-profit-organization-tsunagu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "9ac4d7e9-db9d-4914-8841-24f61c2cc5c1",
+    "name_japan": "藤江",
+    "name_earth": "藤江",
+    "countryCode": "JP",
+    "urlSlug": "jp/akashi-hyogo/teng2-jiang1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "9b277d37-b4d6-4e27-8dbb-e8726fcff766",
+    "name_japan": "あざみ野",
+    "name_earth": "Azamino, Yokohama",
+    "countryCode": "JP",
+    "urlSlug": "jp/yokohama-kanagawa-prefecture/azamino-yokohama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "9b61788b-50cb-45bd-8160-c64a39e15111",
+    "name_japan": "三次",
+    "name_earth": "Miyoshi",
+    "countryCode": "JP",
+    "urlSlug": "jp/miyoshi-hiroshima-prefecture/miyoshi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "9cff3729-57e5-4f58-ae92-d655538d0530",
+    "name_japan": "富谷",
+    "name_earth": "富谷",
+    "countryCode": "JP",
+    "urlSlug": "jp/tomiya-miyagi/fu4-gu3",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "9da287ec-f150-4a68-b4bf-cb735421a764",
+    "name_japan": "南紀田辺",
+    "name_earth": "Nanki-Tanabe, Wakayama",
+    "countryCode": "JP",
+    "urlSlug": "jp/tanabe-wakayama-prefecture/nanki-tanabe-wakayama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "9f02bd31-4392-44fe-8a09-d7267b1a1991",
+    "name_japan": "金沢",
+    "name_earth": "Kanazawa, Ishikawa @ HackforPlay",
+    "countryCode": "JP",
+    "urlSlug": "jp/kanazawa-ishikawa-prefecture/kanazawa-ishikawa-hackforplay",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a127c893-cb9e-4564-b69f-9877f107c08a",
+    "name_japan": "津山",
+    "name_earth": "津山",
+    "countryCode": "JP",
+    "urlSlug": "jp/tsuyama-okayama-prefecture/jin1-shan1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a23e305c-493e-4738-b46e-48a8a9e86987",
+    "name_japan": "住吉",
+    "name_earth": "住吉",
+    "countryCode": "JP",
+    "urlSlug": "jp/osaka/zhu4-ji2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a273ea5c-2998-448e-8d61-b48de632d9af",
+    "name_japan": "西神",
+    "name_earth": "Seishin",
+    "countryCode": "JP",
+    "urlSlug": "jp/kobe-hyogo/seishin",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a2777888-5a0e-489a-ab1d-3e9760f4a447",
+    "name_japan": "宮古島",
+    "name_earth": "Miyakojima",
+    "countryCode": "JP",
+    "urlSlug": "jp/chong1-sheng2-xian4/miyakojima",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a3925e95-810e-4bd0-bfcf-f498884c51c4",
+    "name_japan": "高槻",
+    "name_earth": "Takatsuki",
+    "countryCode": "JP",
+    "urlSlug": "jp/takatsuki-osaka-prefecture/takatsuki",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a889512c-8a4a-48bb-8100-c07cb514a931",
+    "name_japan": "柏",
+    "name_earth": "Kashiwa",
+    "countryCode": "JP",
+    "urlSlug": "jp/chiba-ken/kashiwa-shi/kashiwa",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "a99f7d3a-203d-4858-9f39-b0ebb720d2f5",
+    "name_japan": "山形",
+    "name_earth": "Yamagata",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-yamagata/yamagata",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ac3f82c7-1505-49e1-b92b-e0cf86a3ecfb",
+    "name_japan": "西尾",
+    "name_earth": "Nishio, Aichi",
+    "countryCode": "JP",
+    "urlSlug": "jp/nishio-aichi-prefecture/nishio-aichi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "adf6ea8c-9a1b-4d91-9263-23f70155577e",
+    "name_japan": "足利",
+    "name_earth": "足利＠マチノテ",
+    "countryCode": "JP",
+    "urlSlug": "jp/ashikaga-tochigi/machinote",
+    "status": "PLANNING"
+  },
+  {
+    "id": "af4cbdbe-95b1-4ec1-b74e-f3eb7d44be64",
+    "name_japan": "水戸",
+    "name_earth": "Mito",
+    "countryCode": "JP",
+    "urlSlug": "jp/mito-ibaraki-prefecture/mito",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b0fd6944-6630-4440-ae2b-1c1423df6cd4",
+    "name_japan": "調布",
+    "name_earth": "Chofu",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-dong1-jing1-du1-diao4-bu4-shi4/chofu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b21b22ed-00d7-4d2c-a90e-919a70b2b634",
+    "name_japan": "品川御殿山",
+    "name_earth": "Shinagawa Gotenyama",
+    "countryCode": "JP",
+    "urlSlug": "jp/shinagawa-tokyo/shinagawa-gotenyama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b4fefae6-214f-4afd-b404-20a6062e83ba",
+    "name_japan": "末広町@アミュレット",
+    "name_earth": "Suehirocho@AMULET",
+    "countryCode": "JP",
+    "urlSlug": "jp/chiyoda-tokyo/suehirocho-amulet",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b5614bc7-6348-4fed-be22-4831bdefae5a",
+    "name_japan": "豊中南",
+    "name_earth": "豊中南",
+    "countryCode": "JP",
+    "urlSlug": "jp/da4-ban3-fu3-li3-zhong1-shi4-da4-hei1-ting3/li3-zhong1-nan2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b638526d-bae5-4d13-aa16-1d4461cbc3ee",
+    "name_japan": "松本",
+    "name_earth": "松本@松本大学",
+    "countryCode": "JP",
+    "urlSlug": "jp/matsumoto-nagano-prefecture/song1-ben3-song1-ben3-da4-xue2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b68673dd-6ad2-4c26-b3be-c2c5b1fd6685",
+    "name_japan": "柏の葉",
+    "name_earth": "Kashiwa-no-ha",
+    "countryCode": "JP",
+    "urlSlug": "jp/kashiwa-chiba-prefecture/kashiwa-no-ha",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b7038c6b-1ded-4772-ad66-9dd3ff914390",
+    "name_japan": "宮崎",
+    "name_earth": "Miyazaki",
+    "countryCode": "JP",
+    "urlSlug": "jp/miyazaki-miyazaki-prefecture/miyazaki",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b791f2e8-7cc1-4398-ae86-c8bdc2c14168",
+    "name_japan": "うるま",
+    "name_earth": "Uruma, Okinawa @ Hiramiya",
+    "countryCode": "JP",
+    "urlSlug": "jp/uruma-okinawa-prefecture/uruma-okinawa-hiramiya-1",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "b939046d-a3b0-486a-bc88-09679fe800fe",
+    "name_japan": "三島・沼津",
+    "name_earth": "Mishima/Numazu @ Shizuoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/numazu-shizuoka-prefecture/mishima-numazu-shizuoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "bba216fc-b2af-49b9-98f3-a5ba46579da6",
+    "name_japan": "品川港南",
+    "name_earth": "CoderDojo 品川港南",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "bcb999f5-9b59-4b21-a88b-b66b90aafecf",
+    "name_japan": "福岡",
+    "name_earth": "Fukuoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/chuo-ward-fukuoka-prefecture/fukuoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "bcf764a4-0650-4a2b-8176-9c478d635632",
+    "name_japan": "泉",
+    "name_earth": "Izumi",
+    "countryCode": "JP",
+    "urlSlug": "jp/2-14-4-teraoka-izumi-ku-sendai-shi-miyagi/izumi-2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "bd0c0cdc-d14a-4f2a-8c2b-18bf7c933105",
+    "name_japan": "岡南",
+    "name_earth": "Konan, Okayama",
+    "countryCode": "JP",
+    "urlSlug": "jp/okayama-okayama-prefecture/konan-okayama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "bf17672b-d791-499e-8954-ed65b145f9aa",
+    "name_japan": "青梅",
+    "name_earth": "OME, Tokyo @ City Welfare Council",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-tokyo/ome-tokyo-city-welfare-council",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "c4e6ae34-51c9-4e25-95e2-c498cf84fc9a",
+    "name_japan": "まちだ",
+    "name_earth": "Machida",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-tokyo/machida",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "c6d9f5ed-23c5-43ae-90fb-20e6edc02599",
+    "name_japan": "和歌山",
+    "name_earth": "Wakayama",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-he2-ge1-shan1-xian4-he2-ge1-shan1-shi4/wakayama",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "c7894750-2362-43f8-8336-1167a1c914e7",
+    "name_japan": "香椎",
+    "name_earth": "Kashii, Fukuoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/fukuoka-higashi-ward-fukuoka-prefecture/kashii-fukuoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "c8fd50c6-0145-44d5-8d93-161168b177e2",
+    "name_japan": "富士宮",
+    "name_earth": "富士宮",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "c9729663-2c23-48bd-ae45-071a5e54291a",
+    "name_japan": "鶴岡",
+    "name_earth": "Tsuruoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/tsuruoka-yamagata/tsuruoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "c9841a4d-e977-49f6-b3d4-9a9b3d72e391",
+    "name_japan": "浜松",
+    "name_earth": "Hamamatsu @ Shizuoka",
+    "countryCode": "JP",
+    "urlSlug": "jp/hamamatsu-shizuoka-prefecture/hamamatsu-shizuoka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "cb5e54eb-717b-42ee-88a3-fa7eb1b66fc5",
+    "name_japan": "恵那",
+    "name_earth": "Ena",
+    "countryCode": "JP",
+    "urlSlug": "jp/qi2-fu4-xian4-hui4-na4-shi4-ming2-zhi4-ting3/ena",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ccc1a8fc-3e37-4f32-a4a0-36862f85bb76",
+    "name_japan": "矢吹",
+    "name_earth": "Yabuki",
+    "countryCode": "JP",
+    "urlSlug": "jp/yabuki-fukushima/yabuki",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ce5cc9fd-59c6-4e11-863e-17218face5fc",
+    "name_japan": "晴海",
+    "name_earth": "CoderDojo HARUMI",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ce8d569c-a704-428d-a0ed-5d0bf8beff48",
+    "name_japan": "沖縄@ぴあ",
+    "name_earth": "沖縄@ぴあ",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-okinawa/pia",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ce99d5a6-645f-4c08-9edc-f5660553a35e",
+    "name_japan": "二本松",
+    "name_earth": "二本松@市民交流センター",
+    "countryCode": "JP",
+    "urlSlug": "jp/nihonmatsu-fukushima/sent",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "d6a7d7e6-6043-4efd-bba4-db5abf0d6372",
+    "name_japan": "嘉手納",
+    "name_earth": "Kadena, Okinawa",
+    "countryCode": "JP",
+    "urlSlug": "jp/kadena-okinawa-prefecture/kadena-okinawa",
+    "status": "PLANNING"
+  },
+  {
+    "id": "d7178c1a-1372-4314-aee9-bb9444a2364a",
+    "name_japan": "なかもず",
+    "name_earth": "Nakamozu @ S-Cube",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "d7563ebf-f2d6-491e-9be8-8b0bd856ed4f",
+    "name_japan": "浦安",
+    "name_earth": "Urayasu",
+    "countryCode": "JP",
+    "urlSlug": "jp/urayasu-chiba-prefecture/urayasu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "d9a2266b-d2c3-4541-9ff2-0a665a76be00",
+    "name_japan": "紫雲",
+    "name_earth": "Shiun, Kagawa",
+    "countryCode": "JP",
+    "urlSlug": "jp/takamatsu-kagawa-prefecture/shiun-kagawa",
+    "status": "PLANNING"
+  },
+  {
+    "id": "da06459a-8b91-459b-8c2c-a81b46c791d7",
+    "name_japan": "たかおか",
+    "name_earth": "たかおか@Fablab",
+    "countryCode": "JP",
+    "urlSlug": "jp/takaoka-city-toyama/takaokafablab",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ddfc605d-5cb8-49f6-a0ac-82884577f70e",
+    "name_japan": "こだいら",
+    "name_earth": "CoderDojo Kodaira",
+    "countryCode": "JP",
+    "urlSlug": "jp/t-ky-to/kodaira-tokyo/kodaira",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "deb9b382-737b-492e-83c1-9c1ac77098ac",
+    "name_japan": "日本橋",
+    "name_earth": "日本橋",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "dee0c196-91ca-446d-86e6-7fb30a47b83a",
+    "name_japan": "市川真間",
+    "name_earth": "Ichikawa-Mama, Chiba",
+    "countryCode": "JP",
+    "urlSlug": "jp/ichikawa-chiba-prefecture/ichikawa-mama-chiba",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e00d3a01-0620-4ac7-a9c6-508e9ef361ad",
+    "name_japan": "木曽",
+    "name_earth": "Kiso @ Mintsuku",
+    "countryCode": "JP",
+    "urlSlug": "jp/nagiso-nagano/kiso-mintsuku",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e03205bc-4467-4431-9fa7-5b12b6cf3b7e",
+    "name_japan": "熊本",
+    "name_earth": "Kumamoto @ Kyusyu",
+    "countryCode": "JP",
+    "urlSlug": "jp/kumamoto-kumamoto-prefecture/kumamoto-kyusyu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e1447ba8-ba14-4350-927e-334fce62a24a",
+    "name_japan": "神戸",
+    "name_earth": "Kobe, Hyogo",
+    "countryCode": "JP",
+    "urlSlug": "jp/chuo-ward-hyogo-prefecture/kobe-hyogo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e15893b1-7d2d-484e-a8ba-31f3197d5cf1",
+    "name_japan": "師勝",
+    "name_earth": "shikatsu",
+    "countryCode": "JP",
+    "urlSlug": "jp/kitanagoya-aichi-prefecture/shikatsu",
+    "status": "PLANNING"
+  },
+  {
+    "id": "e211e285-a6bb-46e3-b147-0edb45b18744",
+    "name_japan": "上市",
+    "name_earth": "Kamiichi@Ultinet",
+    "countryCode": "JP",
+    "urlSlug": "jp/kamiichi-town-toyama/kamiichi-ultinet",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e30947bb-ee5d-4960-973d-bb5d97d931d4",
+    "name_japan": "岩国",
+    "name_earth": "岩国",
+    "countryCode": "JP",
+    "urlSlug": "jp/iwakuni-yamaguchi/yan2-guo2",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e3973157-00f6-435e-b34b-043f7a8dc767",
+    "name_japan": "古河",
+    "name_earth": "Koga, Ibaraki",
+    "countryCode": "JP",
+    "urlSlug": "jp/koga-ibaraki/koga-ibaraki",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e50545a6-eafa-4841-8829-a018ba18a721",
+    "name_japan": "福山大門",
+    "name_earth": "Fukuyama Daimon@ Community Center",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-hiroshima/fukuyama-daimon-community-center",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e527094d-5525-4188-a239-5b1c568a8495",
+    "name_japan": "恵庭",
+    "name_earth": "Eniwa",
+    "countryCode": "JP",
+    "urlSlug": "jp/eniwa-hokkaido-prefecture/eniwa",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e82f29a3-25dd-4d4c-b2cf-1ba6f87f46d4",
+    "name_japan": "松戸",
+    "name_earth": "Matsudo",
+    "countryCode": "JP",
+    "urlSlug": "jp/ri4-ben3-qian1-ye4-xian4-song1-hu4-shi4/matsudo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "e8ff33b5-4140-4d25-b924-91bc22f06a96",
+    "name_japan": "鹿児島",
+    "name_earth": "Kagoshima@GenbaSupport",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan-kagoshima-prefecture/kagoshima-genbasupport",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ea49c09a-2c90-47c8-a11d-6764efbc2d47",
+    "name_japan": "会津",
+    "name_earth": "Aizu",
+    "countryCode": "JP",
+    "urlSlug": "jp/suo3-zai4-di4-hui4-jin1-ruo4-song1-shi4-men2-tian2-ting3-da4-zi4-zhong1-ye3-zi4-da4-dao4-xi1/aizu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ebc0a31a-bbc2-45d3-a844-4fad410f2191",
+    "name_japan": "南柏",
+    "name_earth": "Minami-Kashiwa",
+    "countryCode": "JP",
+    "urlSlug": "jp/kashiwa-chiba-prefecture/minami-kashiwa",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ee13db6f-0ffc-441c-bf7b-dea550233bd0",
+    "name_japan": "平野@YOZORA LABO",
+    "name_earth": "平野@ YOZORA LABO",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "ee79a38d-ab3f-43e6-b933-6b444fb3c8c2",
+    "name_japan": "尾張",
+    "name_earth": "Owari",
+    "countryCode": "JP",
+    "urlSlug": "jp/iwakura-aichi-prefecture/owari",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "eecbd90a-0fdb-41dc-94e5-d3e9f6d6d57e",
+    "name_japan": "神山",
+    "name_earth": "Kamiyama, Tokushima @ JA uetsuno",
+    "countryCode": "JP",
+    "urlSlug": "jp/kamiyama-tokushima-prefecture/kamiyama-tokushima-ja-uetsuno",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f126911d-5a5e-4fbe-89ef-de2feb46a232",
+    "name_japan": "なんと@よってカフェ",
+    "name_earth": "なんと@よってカフェ",
+    "countryCode": "JP",
+    "urlSlug": "jp/nanto-toyama/nantoyottekafu",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f18cb267-047a-4885-bb6d-2cf154d54300",
+    "name_japan": "稲城",
+    "name_earth": "Inagi",
+    "countryCode": "JP",
+    "urlSlug": "jp/inagi-tokyo/inagi",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f1c974d7-24c1-487b-b2b4-923c9468e6aa",
+    "name_japan": "和歌山有田",
+    "name_earth": "和歌山有田",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f3a379c1-46c5-4a9f-9f9f-6469f0aa05d3",
+    "name_japan": "鳥取",
+    "name_earth": "Tottori",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan/tottori",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f5f518e4-4239-4b4a-8d15-735885ae1afc",
+    "name_japan": "さくら",
+    "name_earth": "Sakura",
+    "countryCode": "JP",
+    "urlSlug": "jp/hcc/sakura",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f8a7ac3b-2b70-4a8b-a310-2f8ee127a9b9",
+    "name_japan": "飯能",
+    "name_earth": "Hanno",
+    "countryCode": "JP",
+    "urlSlug": "jp/saitama-ken/qi2-yu4-xian4-fan4-neng2-shi4-mei3-shan1-tai2-mei3-shan1-tai2-gong1-min2-guan3/hanno",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "f9a2e202-8ef0-4b7a-96e8-07b61451fcc0",
+    "name_japan": "瀬戸",
+    "name_earth": "瀬戸",
+    "countryCode": "JP",
+    "urlSlug": "jp/japan/lai4-hu4",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "fa0ae0bf-b6b3-4d57-975b-6f095ab89c7a",
+    "name_japan": "長岡京",
+    "name_earth": "Nagaokakyo, Kyoto",
+    "countryCode": "JP",
+    "urlSlug": "jp/nagaokakyo-city-kyoto/nagaokakyo-kyoto",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "fa322844-dcb5-465a-be41-269f17dbe6e7",
+    "name_japan": "光",
+    "name_earth": "Hikari @ HiKARiBA",
+    "countryCode": "JP",
+    "urlSlug": "jp/hikari-yamaguchi-prefecture/hikari-hikariba",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "fc1fb126-fe99-4ef6-b8db-46f348869369",
+    "name_japan": "ひたちなか",
+    "name_earth": "Hitachinaka",
+    "countryCode": "JP",
+    "urlSlug": "jp/hitachinaka-6-5/hitachinaka",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "fcfec8ee-b0d5-442a-bdb1-1ec12c467bb2",
+    "name_japan": "守谷",
+    "name_earth": "Moriya",
+    "countryCode": "JP",
+    "urlSlug": "jp/moriya-ibaraki-prefecture/moriya",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "id": "fdd3304b-486d-495f-b53e-0de47102dc6d",
+    "name_japan": "甲府",
+    "name_earth": "甲府 @ 山梨県立青少年センター",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  }
+]

--- a/_tasks/upsert_dojos_geojson.rb
+++ b/_tasks/upsert_dojos_geojson.rb
@@ -62,6 +62,7 @@ end
 features    = []
 description = ''
 japan_count = 0
+japan_dojos = []
 marked_dojos = []
 dojos_earth.each do |dojo|
   # 緯度または経度データが無いクラブはスキップ（地図上に配置できないため）
@@ -96,7 +97,8 @@ dojos_earth.each do |dojo|
       # Japan DB 上で Inactive ならスキップ (Clubs DB より厳密に管理されているため)
       next if name2is_active[zen2japan[dojo[:name]]] == false
 
-      # Clubs API 上のクラブ名を Japan DB 上のクラブ前に変換する by Hash
+      # Clubs API 上のクラブ名を Japan DB 上のクラブ名に変換する
+      dojo[:name_earth] = dojo[:name]
       dojo[:name] = zen2japan[dojo[:name]] if zen2japan[dojo[:name]]
 
       # デバッグ用: 地図上に配置したクラブ数をコンソールに出力する
@@ -131,6 +133,16 @@ dojos_earth.each do |dojo|
       HTML
     end
 
+    # 名寄せ用に ID と日本語名を控える
+    japan_dojos << {
+      id:          dojo[:id],
+      name_japan:  dojo[:name],
+      name_earth:  dojo[:name_earth],
+      countryCode: dojo[:countryCode],
+      urlSlug:     dojo[:urlSlug],
+      status:      dojo[:status],
+     } if dojo[:countryCode] == "JP"
+
     # 地図上に配置するため GeoJSON 形式に変換する
     # https://ja.wikipedia.org/wiki/GeoJSON
     features << {
@@ -159,3 +171,7 @@ File.open("dojos.geojson", "w") do |file|
   file.write(DOJOS_GEOJSON)
   #JSON.dump(geojson, file)
 end
+
+# 名寄せ前/名寄せ後の比較用データを保存
+IO.write "_data/dojo2dojo.json", JSON.pretty_generate(japan_dojos)
+

--- a/dojo2dojo.json
+++ b/dojo2dojo.json
@@ -1,0 +1,4 @@
+---
+layout: none
+---
+{{ site.data.dojo2dojo | jsonify }}


### PR DESCRIPTION
## 概要
[coderdojo.jp PR #1747](https://github.com/coderdojo-japan/coderdojo.jp/pull/1747) の実装のため、Clubs API と Japan DB の名前マッピングを比較するエンドポイントを追加します。

## 背景
- PR #1747 では、Clubs API の名前 (name_earth) と Japan DB の名前 (name_japan) および ID の比較が必要
- 現在は Google Sheets から手動でコピー＆ペーストしている `dojo2dojo.csv` を使用
- `global_club_id` を使用した自動化により、この手動プロセスを廃止したい

## 変更内容

### 1. 名寄せデータ記録機能の追加
`_tasks/upsert_dojos_geojson.rb` に以下の機能を追加：
- Clubs API と Japan DB の名前マッピング情報を記録
- `_data/dojo2dojo.json` として保存

### 2. Jekyll エンドポイントの追加
- `/dojo2dojo.json` エンドポイントを追加
- `_data/dojo2dojo.json` のデータを JSON として提供
- `japan.json` と同じパターンで実装

http://map.coderdojo.jp/dojo2dojo.json

## 提供されるデータ形式
```json
[
  {
    "global_club_id": 12345,
    "name_japan": "CoderDojo 札幌",
    "name_earth": "Sapporo",
    "countryCode": "JP",
    "urlSlug": "sapporo-jp",
    "status": "RUNNING_SESSIONS"
  },
  ...
]
```

## 目的
- **主要目的**: https://github.com/coderdojo-japan/coderdojo.jp/pull/1747 の実装
- **最終目標**: `global_club_id` を使用した自動化により、手動管理の `dojo2dojo.csv` を廃止

## 注記
これは PR #1747 の実装支援のための一時的なエンドポイントです。`global_club_id` による完全な自動化が実現した際には、より良い実装に置き換えられる可能性があります。