### PR TITLE
Jekyllビルド時のデータ更新を自動化

### DIFF
--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -89,8 +89,7 @@ jobs:
 
     - name: 🔧 Build & Test
       run: |
-        # Convert human-readable Geojson file into computer-friendly one
-        bundle exec rake compact_geojson
+        # Jekyll plugin automatically runs upsert_dojos_geojson, compact_geojson, and cache_dojo_logos
         JEKYLL_ENV=production bundle exec jekyll build
         JEKYLL_ENV=production bundle exec jekyll doctor
         SKIP_BUILD=true       bundle exec rake test

--- a/_data/dojo2dojo.json
+++ b/_data/dojo2dojo.json
@@ -112,6 +112,14 @@
     "status": "RUNNING_SESSIONS"
   },
   {
+    "global_club_id": "1178be6f-f652-4dd1-bf95-3a8b9300b7a3",
+    "name_japan": "SAGA@駅前中央",
+    "name_earth": "CoderDojo SAGA@駅前中央",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
     "global_club_id": "1237536f-44cf-44a7-8fb6-464fb12f3865",
     "name_japan": "神楽坂",
     "name_earth": "CoderDojo Kagurazaka",
@@ -197,6 +205,14 @@
     "name_earth": "Kamagaya, Chiba",
     "countryCode": "JP",
     "urlSlug": "jp/qian1-ye4-xian4/kamagaya-chiba",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "global_club_id": "1a5ece9e-b149-4cd1-b05f-9a3b8b39bb7a",
+    "name_japan": "八女",
+    "name_earth": "CoderDojo八女",
+    "countryCode": "JP",
+    "urlSlug": null,
     "status": "RUNNING_SESSIONS"
   },
   {
@@ -376,6 +392,14 @@
     "status": "RUNNING_SESSIONS"
   },
   {
+    "global_club_id": "3a2f68c8-b54a-412b-bf28-915df1563b85",
+    "name_japan": "鳥羽@竹田住設",
+    "name_earth": "鳥羽 @ 竹田住設",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
     "global_club_id": "3d037ab0-1ba5-4c94-97ef-2898a37bdb68",
     "name_japan": "多摩センター",
     "name_earth": "Tama Center @ Tokyo",
@@ -469,6 +493,14 @@
     "name_earth": "Ikebukuro,Tokyo @ Unique-inet",
     "countryCode": "JP",
     "urlSlug": "jp/ri4-ben3-dong1-jing1-du1-li3-dao3-qu1/ikebukuro-tokyo-unique-inet",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "global_club_id": "4e31fc13-205c-4738-9b62-2722d890f6ed",
+    "name_japan": "砧",
+    "name_earth": "CoderDojo砧",
+    "countryCode": "JP",
+    "urlSlug": null,
     "status": "RUNNING_SESSIONS"
   },
   {
@@ -696,6 +728,14 @@
     "status": "RUNNING_SESSIONS"
   },
   {
+    "global_club_id": "7b441779-c5ab-45af-8823-1a87e95e5d6a",
+    "name_japan": "新大阪",
+    "name_earth": "CoderDojo新大阪",
+    "countryCode": "JP",
+    "urlSlug": null,
+    "status": "RUNNING_SESSIONS"
+  },
+  {
     "global_club_id": "7c0ca939-b98e-4fa5-aa6c-dcdf2cffd280",
     "name_japan": "浦和@Urawa Minecraft Club",
     "name_earth": "Urawa @ Urawa Minecraft Club",
@@ -765,6 +805,14 @@
     "name_earth": "Inagawa, Hyogo",
     "countryCode": "JP",
     "urlSlug": "jp/japan/inagawa-hyogo",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "global_club_id": "84f71084-cbb9-4712-b0fc-1e15cd47f90f",
+    "name_japan": "赤坂国際",
+    "name_earth": "Coders International Tokyo",
+    "countryCode": "JP",
+    "urlSlug": null,
     "status": "RUNNING_SESSIONS"
   },
   {
@@ -1149,6 +1197,14 @@
     "name_earth": "二本松@市民交流センター",
     "countryCode": "JP",
     "urlSlug": "jp/nihonmatsu-fukushima/sent",
+    "status": "RUNNING_SESSIONS"
+  },
+  {
+    "global_club_id": "d600a123-6181-418a-80ee-20a25d9af6e1",
+    "name_japan": "南会津",
+    "name_earth": "CoderDojo南会津",
+    "countryCode": "JP",
+    "urlSlug": null,
     "status": "RUNNING_SESSIONS"
   },
   {

--- a/_plugins/build_hooks.rb
+++ b/_plugins/build_hooks.rb
@@ -1,0 +1,18 @@
+# Pre-build tasks that run before Jekyll builds the site
+Jekyll::Hooks.register :site, :after_init do |site|
+  puts "🔄 Running pre-build tasks..."
+
+  # Update GeoJSON data
+  puts "  → Updating dojos.geojson..."
+  system('bundle exec rake upsert_dojos_geojson')
+
+  # Compact GeoJSON for production
+  puts "  → Creating dojos.min.geojson..."
+  system('bundle exec rake compact_geojson')
+
+  # Cache dojo logos
+  puts "  → Caching dojo logos..."
+  system('bundle exec rake cache_dojo_logos')
+
+  puts "✅ Pre-build tasks completed"
+end

--- a/dojos.geojson
+++ b/dojos.geojson
@@ -1251,6 +1251,21 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
+          130.2969361,
+          33.2625159
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://coderdojosaga-ekimaechuo.connpass.com/' target='_blank' rel='noopener'>  <img src='/images/dojos/saga-ekimae-chuo.webp' alt='SAGA@駅前中央' loading='lazy' width='100px' /></a><br><b>SAGA@駅前中央</b><br>佐賀市で毎月土曜開催<br>&rarr; 次回: <a href='https://coderdojosaga-ekimaechuo.connpass.com/event/380000/' target='_blank' rel='noopener'>2月7日</a><br><a href='https://coderdojosaga-ekimaechuo.connpass.com/' target='_blank' rel='noopener'>Webサイトを見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
           -84.12722819999999,
           33.4429741
         ]
@@ -2039,6 +2054,21 @@
         "marker-size": "small",
         "marker-symbol": "coderdojo",
         "description": "<img src='/images/coderdojo.webp' alt='CoderDojo logo' width='100px' /><br>Douala @ Mbcode<br><a target='_blank' rel='noopener'   href='http://zen.coderdojo.com/dojos/cm/douala/douala-mbcode'>連絡先を見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          130.58926123030565,
+          33.20941641677492
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://coderdojo-yame.connpass.com/' target='_blank' rel='noopener'>  <img src='/images/dojos/default.webp' alt='八女' loading='lazy' width='100px' /></a><br><b>八女</b><br>八女市で毎月開催<br>&rarr; 次回: <a href='https://coderdojo-yame.connpass.com/event/377954/' target='_blank' rel='noopener'>1月24日</a><br><a href='https://coderdojo-yame.connpass.com/' target='_blank' rel='noopener'>Webサイトを見る</a>"
       }
     },
     {
@@ -4611,6 +4641,21 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
+          136.84652696727548,
+          34.467252707825104
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://ict.toba.city/' target='_blank' rel='noopener'>  <img src='/images/dojos/default.webp' alt='鳥羽@竹田住設' loading='lazy' width='100px' /></a><br><b>鳥羽@竹田住設</b><br>鳥羽市で隔週開催<br><a href='https://ict.toba.city/' target='_blank' rel='noopener'>Webサイトを見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
           44.91742224885461,
           31.98337641289415
         ]
@@ -5999,6 +6044,21 @@
         "marker-size": "small",
         "marker-symbol": "coderdojo",
         "description": "<img src='/images/coderdojo.webp' alt='CoderDojo logo' width='100px' /><br>Valbelluna<br><a target='_blank' rel='noopener'   href='http://zen.coderdojo.com/dojos/it/belluno-province-of-belluno/valbelluna'>連絡先を見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          139.6005872,
+          35.6411816
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://codeclub.org/ja/clubs/4e31fc13-205c-4738-9b62-2722d890f6ed' target='_blank' rel='noopener'>  <img src='/images/dojos/kinuta.webp' alt='砧' loading='lazy' width='100px' /></a><br><b>砧</b><br>世田谷区で毎月開催<br><a href='https://codeclub.org/ja/clubs/4e31fc13-205c-4738-9b62-2722d890f6ed' target='_blank' rel='noopener'>Webサイトを見る</a>"
       }
     },
     {
@@ -9501,6 +9561,21 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
+          135.5036897,
+          34.7320639
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://coderdojo-shin-osaka.connpass.com/' target='_blank' rel='noopener'>  <img src='/images/dojos/shin-osaka.webp' alt='新大阪' loading='lazy' width='100px' /></a><br><b>新大阪</b><br>大阪市東淀川区で<br>毎月開催<br>&rarr; 次回: <a href='https://coderdojo-shin-osaka.connpass.com/event/378697/' target='_blank' rel='noopener'>1月17日</a><br><a href='https://coderdojo-shin-osaka.connpass.com/' target='_blank' rel='noopener'>Webサイトを見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
           -80.633856,
           35.431148
         ]
@@ -10274,6 +10349,21 @@
         "marker-size": "small",
         "marker-symbol": "coderdojo",
         "description": "<img src='/images/coderdojo.webp' alt='CoderDojo logo' width='100px' /><br>CoderDojo@Najaf<br><a target='_blank' rel='noopener'   href='http://zen.coderdojo.com/dojos/iq/najaf/coderdojo-najaf'>連絡先を見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          139.73212228447724,
+          35.668044491047944
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://altairxiii.wixsite.com/cit-coder-dojo' target='_blank' rel='noopener'>  <img src='/images/dojos/default.webp' alt='赤坂国際' loading='lazy' width='100px' /></a><br><b>赤坂国際</b><br>港区赤坂で隔週開催<br><a href='https://altairxiii.wixsite.com/cit-coder-dojo' target='_blank' rel='noopener'>Webサイトを見る</a>"
       }
     },
     {
@@ -16844,6 +16934,21 @@
         "marker-size": "small",
         "marker-symbol": "coderdojo",
         "description": "<img src='/images/coderdojo.webp' alt='CoderDojo logo' width='100px' /><br>Deventer<br><a target='_blank' rel='noopener'   href='http://zen.coderdojo.com/dojos/nl/deventer/deventer'>連絡先を見る</a>"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          139.7737687,
+          37.2004629
+        ]
+      },
+      "properties": {
+        "marker-size": "small",
+        "marker-symbol": "coderdojo",
+        "description": "<a href='https://coderdojo-minamiaizu.doorkeeper.jp/' target='_blank' rel='noopener'>  <img src='/images/dojos/default.webp' alt='南会津' loading='lazy' width='100px' /></a><br><b>南会津</b><br>南会津で不定期開催<br>&rarr; 次回: <a href='https://coderdojo-minamiaizu.doorkeeper.jp/events/194071' target='_blank' rel='noopener'>1月31日</a><br><a href='https://coderdojo-minamiaizu.doorkeeper.jp/' target='_blank' rel='noopener'>Webサイトを見る</a>"
       }
     },
     {


### PR DESCRIPTION
## 概要

Jekyllビルド時に自動的にデータ更新タスクを実行するプラグインを追加し、GitHub Actionsワークフローを最適化しました。

## 変更内容

### 1. Jekyllビルドフック追加（`_plugins/build_hooks.rb`）

`jekyll build` または `jekyll server` 実行時に自動的に以下のRakeタスクを実行：
- `upsert_dojos_geojson`: GeoJSON生成
- `compact_geojson`: GeoJSON圧縮（22.9%削減）
- `cache_dojo_logos`: Dojoロゴキャッシュ

### 2. GitHub Actions最適化（`scheduler_daily.yml`）

- 二重実行していた `compact_geojson` を削除
- Jekyllプラグインが自動実行するため不要に

### 3. その他の改善

- Dojo名マッピングを更新（新規7件追加、既存2件修正）
- GeoJSONを再生成して新規Dojoマッピングを反映

## 効果

- ✅ ローカル開発でも本番環境でも一貫した動作
- ✅ 手動でのRakeタスク実行が不要に
- ✅ ビルド時間の短縮（二重実行の削除）
- ✅ コードの簡潔化

## テスト結果

```bash
# dojos.min.geojsonを削除して再ビルドでテスト
rm -f dojos.min.geojson
bundle exec jekyll build
# → 自動的に再生成されることを確認
```