### PR TITLE
Jekyllビルド時のデータ更新を自動化

### DIFF
--- a/.github/workflows/deploy_to_pages.yml
+++ b/.github/workflows/deploy_to_pages.yml
@@ -26,8 +26,7 @@ jobs:
 
     - name: 🔧 Build & Test
       run: |
-        # Convert human-readable Geojson file into computer-friendly one
-        bundle exec rake compact_geojson
+        # Jekyll plugin automatically runs upsert_dojos_geojson, compact_geojson, and cache_dojo_logos
         JEKYLL_ENV=production bundle exec jekyll build
         JEKYLL_ENV=production bundle exec jekyll doctor
         SKIP_BUILD=true       bundle exec rake test

--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -51,14 +51,10 @@ jobs:
       run: |
         bundle exec rake get_data_from_japan
 
-    - name: ☯️ Cache dojo logos in Japan
+    - name: 📍 Prepare DojoMap data for commit
       run: |
-        bundle exec rake cache_dojo_logos
-
-    - name: 📍 Generate DojoMap from Earth/Japan data
-      run: |
-        bundle exec rake upsert_dojos_geojson
-        bundle exec rake compact_geojson
+        # Jekyll plugin automatically runs cache_dojo_logos, upsert_dojos_geojson, and compact_geojson
+        bundle exec jekyll build
 
     - name: 🆙 Commit latest data to update DojoMap (if any)
       run: |

--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -51,10 +51,16 @@ jobs:
       run: |
         bundle exec rake get_data_from_japan
 
-    - name: 📍 Prepare DojoMap data for commit
+    - name: 🔧 Build data to render DojoMap
       run: |
         # Jekyll plugin automatically runs cache_dojo_logos, upsert_dojos_geojson, and compact_geojson
-        bundle exec jekyll build
+        JEKYLL_ENV=production bundle exec jekyll build
+
+    - name: ✅ Test
+      run: |
+        # _site is already built in previous step
+        JEKYLL_ENV=production bundle exec jekyll doctor
+        SKIP_BUILD=true       bundle exec rake test
 
     - name: 🆙 Commit latest data to update DojoMap (if any)
       run: |
@@ -82,13 +88,6 @@ jobs:
         fi
       env:
         GITHUB_TOKEN:
-
-    - name: 🔧 Build & Test
-      run: |
-        # Jekyll plugin automatically runs upsert_dojos_geojson, compact_geojson, and cache_dojo_logos
-        JEKYLL_ENV=production bundle exec jekyll build
-        JEKYLL_ENV=production bundle exec jekyll doctor
-        SKIP_BUILD=true       bundle exec rake test
 
     # This is NOT for security reason but for others, especially who fork,
     # to easier find out which API key they need to replace with their own.

--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -89,8 +89,7 @@ jobs:
 
     - name: 🔧 Build & Test
       run: |
-        # Convert human-readable Geojson file into computer-friendly one
-        bundle exec rake compact_geojson
+        # Jekyll plugin automatically runs upsert_dojos_geojson, compact_geojson, and cache_dojo_logos
         JEKYLL_ENV=production bundle exec jekyll build
         JEKYLL_ENV=production bundle exec jekyll doctor
         SKIP_BUILD=true       bundle exec rake test

--- a/_plugins/build_hooks.rb
+++ b/_plugins/build_hooks.rb
@@ -1,0 +1,18 @@
+# Pre-build tasks that run before Jekyll builds the site
+Jekyll::Hooks.register :site, :after_init do |site|
+  puts "🔄 Running pre-build tasks..."
+
+  # Update GeoJSON data
+  puts "  → Updating dojos.geojson..."
+  system('bundle exec rake upsert_dojos_geojson')
+
+  # Compact GeoJSON for production
+  puts "  → Creating dojos.min.geojson..."
+  system('bundle exec rake compact_geojson')
+
+  # Cache dojo logos
+  puts "  → Caching dojo logos..."
+  system('bundle exec rake cache_dojo_logos')
+
+  puts "✅ Pre-build tasks completed"
+end


### PR DESCRIPTION
## 概要

Jekyllビルド時に自動的にデータ更新タスクを実行するプラグインを追加し、GitHub Actionsワークフローを大幅に簡潔化・最適化しました。

## 変更内容

### 1. Jekyllビルドフック追加（`_plugins/build_hooks.rb`）

`jekyll build` または `jekyll server` 実行時に自動的に以下のRakeタスクを実行：
- `upsert_dojos_geojson`: GeoJSON生成
- `compact_geojson`: GeoJSON圧縮（22.9%削減）
- `cache_dojo_logos`: Dojoロゴキャッシュ

**メリット**：
- ✅ ローカル開発でも本番環境でも一貫した動作
- ✅ 手動でのRakeタスク実行が不要に
- ✅ `dojo2dojo.csv`更新時も`jekyll build`だけで自動反映

### 2. GitHub Actions大幅最適化

#### `scheduler_daily.yml`
**Before（複数ステップで二重実行）**:
```yaml
- name: ☯️ Cache dojo logos in Japan
  run: bundle exec rake cache_dojo_logos

- name: 📍 Generate DojoMap from Earth/Japan data
  run: |
    bundle exec rake upsert_dojos_geojson
    bundle exec rake compact_geojson

- name: 🆙 Commit latest data  # ← テスト前にコミット

- name: 🔧 Build & Test
  run: |
    bundle exec rake compact_geojson  # 二重実行
    JEKYLL_ENV=production bundle exec jekyll build  # 二重ビルド
    bundle exec jekyll doctor
    bundle exec rake test
```

**After（1ビルド、テスト後コミット）**:
```yaml
- name: 🔧 Build data to render DojoMap
  run: JEKYLL_ENV=production bundle exec jekyll build  # プラグインが自動実行

- name: ✅ Test  # ← テストが通ってから
  run: |
    bundle exec jekyll doctor  # _siteは既にビルド済み
    bundle exec rake test

- name: 🆙 Commit latest data  # ← コミット（安全）
```

**効果**: 
- 二重ビルド・二重実行を完全排除
- テストをコミット前に実行（安全性向上）
- ステップ数削減で理解しやすく

#### `deploy_to_pages.yml`
- `compact_geojson`の二重実行を削除
- Jekyllプラグインが自動実行するため不要に

## テスト結果

```bash
# dojos.min.geojsonを削除して再ビルドでテスト
rm -f dojos.min.geojson
bundle exec jekyll build

# 実行ログ:
# 🔄 Running pre-build tasks...
#   → Updating dojos.geojson...
#   → Creating dojos.min.geojson...
#   ✅ Created dojos.min.geojson
#      Original: 738.9 KB
#      Minified: 569.7 KB
#      Reduction: 22.9%
#   → Caching dojo logos...
#   ✅ Pre-build tasks completed
```

## 実装の考慮点

- **YAGNI原則**: ファイル名は`build_hooks.rb`というシンプルな名前に
- **一貫性**: Rakeタスク経由で実行（`bundle exec rake xxx`）
- **DRY原則**: タスク定義の一元化、二重実行の完全排除
- **安全性**: テストをコミット前に実行（不正データのコミットを防止）
- **シンプルさ**: `_site/`は.gitignoreされているため、`jekyll build`をデータ準備に使用可能

## 全体効果

- ✅ ワークフローが理解しやすく、レビューしやすい
- ✅ コード行数削減（scheduler_daily.yml: 9行削減）
- ✅ ビルド時間短縮（二重実行・二重ビルドの完全排除）
- ✅ 安全性向上（テスト後コミット）
- ✅ 保守性向上（Jekyllプラグインが一元管理）