### PR TITLE
actions/checkout を v4 から v5 に更新（Node.js 20 非推奨警告の解消）

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy_to_pages.yml
+++ b/.github/workflows/deploy_to_pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 📥 Download codes from GitHub
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 2
 

--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: 📥 Download codes from GitHub
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 2
 


### PR DESCRIPTION
## 背景

PR #28 のデプロイ実行時に、GitHub Actions から Node.js 20 非推奨の警告が出ていた:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4.
```

## 対応

`actions/checkout@v4` → `@v5`（Node.js 24 対応）に更新。

対象ワークフロー:
- `deploy_to_pages.yml`
- `scheduler_daily.yml`
- `claude-review.yml`

## 補足

警告で名指しされたのは `actions/checkout@v4` のみ。他のアクション
（`ruby/setup-ruby@v1`・`peaceiris/actions-gh-pages@v4`・`slackapi/slack-github-action@v1.24.0`）
は警告対象外のため変更なし。