### PR TITLE
マーカー方式テスト用ページ /test.html /default.html /coderdojo.html を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ vendor/
 
 # Generated files
 dojos.min.geojson
+
+# Generated marker-mode variants (for test pages /default.html /coderdojo.html)
+dojos.default.geojson
+dojos.default.min.geojson
+dojos.coderdojo.geojson
+dojos.coderdojo.min.geojson

--- a/_tasks/compact_geojson.rb
+++ b/_tasks/compact_geojson.rb
@@ -1,20 +1,21 @@
 #!/usr/bin/env ruby
 require 'json'
 
-# Create a minified version of dojos.geojson for production use
-geojson = JSON.load(File.read("dojos.geojson"))
+# dojos.geojson とモード別バリアント(dojos.default.geojson 等)の最小化版を生成する。
+# 本番 index.html は dojos.min.geojson を、テストページ /#{mode}.html は
+# dojos.#{mode}.min.geojson を読み込む。
+sources = Dir.glob("dojos*.geojson").reject { |path| path.end_with?(".min.geojson") }.sort
 
-# Write minified version (no whitespace)
-File.open('dojos.min.geojson', 'w') do |file|
-  JSON.dump(geojson, file)
+sources.each do |src|
+  dest    = src.sub(/\.geojson\z/, ".min.geojson")
+  geojson = JSON.load(File.read(src))
+
+  # Write minified version (no whitespace)
+  File.open(dest, 'w') { |file| JSON.dump(geojson, file) }
+
+  reduction = ((File.size(src) - File.size(dest)) * 100.0 / File.size(src)).round(1)
+  puts "✅ Created #{dest}"
+  puts "   Original: #{(File.size(src) / 1024.0).round(1)} KB"
+  puts "   Minified: #{(File.size(dest) / 1024.0).round(1)} KB"
+  puts "   Reduction: #{reduction}%"
 end
-
-# Calculate size reduction
-original_size = File.size("dojos.geojson")
-minified_size = File.size("dojos.min.geojson")
-reduction = ((original_size - minified_size) * 100.0 / original_size).round(1)
-
-puts "✅ Created dojos.min.geojson"
-puts "   Original: #{(original_size / 1024.0).round(1)} KB"
-puts "   Minified: #{(minified_size / 1024.0).round(1)} KB"
-puts "   Reduction: #{reduction}%"

--- a/_tasks/upsert_dojos_geojson.rb
+++ b/_tasks/upsert_dojos_geojson.rb
@@ -11,14 +11,17 @@ require 'yaml'
 #                  必要で、スプライト サーバ障害時はマーカーが全滅する。
 # 背景: 2026/06 に 'coderdojo' がスプライト サーバ 502 で読めずマーカー全滅した。
 #       詳細は tests/markers_integrity_test.rb 参照。
+#
+# 各モードの GeoJSON を常に生成し、テストページ /default.html /coderdojo.html で
+# モード別にプレビューできるようにする（本番 index.html は marker_mode を使用）。
+MARKER_PROPS = {
+  'default'   => { 'marker-color'  => '#2e9ad9' }, # CoderDojo blue (rgb 46,154,217)
+  'coderdojo' => { 'marker-symbol' => 'coderdojo' },
+}.freeze
+
 config      = File.exist?('_config.yml') ? (YAML.load_file('_config.yml') || {}) : {}
 marker_mode = config['marker'].to_s.empty? ? 'default' : config['marker'].to_s
-marker_props =
-  if marker_mode == 'coderdojo'
-    { 'marker-symbol' => 'coderdojo' }
-  else
-    { 'marker-color'  => '#2e9ad9' } # CoderDojo blue (rgb 46,154,217)
-  end
+marker_mode = 'default' unless MARKER_PROPS.key?(marker_mode)
 
 dojos_earth  = []
 dojos_japan  = []
@@ -171,19 +174,33 @@ dojos_earth.each do |dojo|
       },
       properties: {
         'marker-size'   => 'small', # small, medium, large
-        **marker_props,             # marker-color or marker-symbol (see top of file)
+        # marker-color / marker-symbol はモード別に書き出し時に付与する（下部参照）
         description: description.delete!("\n"),
       }
     }
   end
 end
 
-geojson = {
-  type: "FeatureCollection",
-  features: features
-}
+# 指定モードのマーカー属性を付与した FeatureCollection を組み立てる。
+# プロパティ順序は marker-size → マーカー属性 → description を維持する。
+def build_geojson(features, mode)
+  feats = features.map do |f|
+    base  = f[:properties]
+    props = { 'marker-size' => base['marker-size'] }
+            .merge(MARKER_PROPS.fetch(mode))
+            .merge(description: base[:description])
+    f.merge(properties: props)
+  end
+  { type: "FeatureCollection", features: feats }
+end
 
-# 描画に使う GeoJSON データと、デバッグ用の比較データを保存
-IO.write "dojos.geojson",        JSON.pretty_generate(geojson)
+# 本番用 dojos.geojson は _config.yml の選択モードで書き出す
+IO.write "dojos.geojson", JSON.pretty_generate(build_geojson(features, marker_mode))
+
+# モード別 dojos.#{mode}.geojson も生成（テストページ /#{mode}.html 用）
+MARKER_PROPS.each_key do |mode|
+  IO.write "dojos.#{mode}.geojson", JSON.pretty_generate(build_geojson(features, mode))
+end
+
 IO.write "_data/dojo2dojo.json", JSON.pretty_generate(japan_dojos)
 

--- a/coderdojo.html
+++ b/coderdojo.html
@@ -1,0 +1,69 @@
+---
+sitemap: false
+---
+
+<!-- テストページ: coderdojo マーカー（CoderDojo ロゴ / marker-symbol, スプライト依存）を
+     プレビューする。本番 index.html と同じ Geolonia 設定で data-geojson のみ差し替え。
+     ⚠️ Geolonia スプライト サーバ障害(502)や 'coderdojo' シンボル未登録だと表示されない。
+     生成: _tasks/upsert_dojos_geojson.rb / 関連: tests/markers_integrity_test.rb -->
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[テスト] coderdojo マーカー - DojoMap</title>
+    <meta name="robots" content="noindex">
+    <link href="/images/icons/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+    <style>
+      body, html {
+        width:  100%;
+        height: 100%;
+        margin:  0;
+        padding: 0;
+      }
+      .geolonia {
+        width:  100%;
+        height: 100%;
+      }
+      .maplibregl-popup-content a:visited {
+	color: blue;
+      }
+      #mode-badge {
+        position:   fixed;
+        top:        8px;
+        left:       8px;
+        z-index:    1000;
+        background: rgba(0, 0, 0, 0.7);
+        color:      #fff;
+        font:       12px/1.4 sans-serif;
+        padding:    4px 8px;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="mode-badge">テストページ: coderdojo マーカー (logo, スプライト依存)</div>
+    <div
+      class="geolonia"
+      data-geojson="./dojos.coderdojo.min.geojson"
+      data-lat="35.6809591"
+      data-lng="139.7673068"
+      data-zoom="5"
+      data-marker="off"
+      data-custom-marker="#custom-marker"
+      data-custom-marker-offset="0, 0"
+      data-geolocate-control="on"
+      data-cluster="off"
+      data-cluster-color="rgba(46, 154, 217, 0.8)"
+    ></div>
+
+    <script
+      type="text/javascript"
+      {% if site.env.GEOLONIA_API_KEY %}
+      src="https://cdn.geolonia.com/v1/embed?geolonia-api-key={{ site.env.GEOLONIA_API_KEY }}"
+      {% else %}
+      src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"
+      {% endif %}
+    ></script>
+  </body>
+</html>

--- a/coderdojo.html
+++ b/coderdojo.html
@@ -39,10 +39,13 @@ sitemap: false
         padding:    4px 8px;
         border-radius: 4px;
       }
+      #mode-badge a {
+        color: #9cf;
+      }
     </style>
   </head>
   <body>
-    <div id="mode-badge">テストページ: coderdojo マーカー (logo, スプライト依存)</div>
+    <div id="mode-badge">テストページ: coderdojo マーカー (logo, スプライト依存) · <a href="/test.html">比較</a></div>
     <div
       class="geolonia"
       data-geojson="./dojos.coderdojo.min.geojson"

--- a/default.html
+++ b/default.html
@@ -38,10 +38,13 @@ sitemap: false
         padding:    4px 8px;
         border-radius: 4px;
       }
+      #mode-badge a {
+        color: #9cf;
+      }
     </style>
   </head>
   <body>
-    <div id="mode-badge">テストページ: default マーカー (circle)</div>
+    <div id="mode-badge">テストページ: default マーカー (circle) · <a href="/test.html">比較</a></div>
     <div
       class="geolonia"
       data-geojson="./dojos.default.min.geojson"

--- a/default.html
+++ b/default.html
@@ -1,0 +1,68 @@
+---
+sitemap: false
+---
+
+<!-- テストページ: default マーカー（circle / marker-color, スプライト非依存）を
+     プレビューする。本番 index.html と同じ Geolonia 設定で data-geojson のみ差し替え。
+     生成: _tasks/upsert_dojos_geojson.rb / 関連: tests/markers_integrity_test.rb -->
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[テスト] default マーカー - DojoMap</title>
+    <meta name="robots" content="noindex">
+    <link href="/images/icons/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+    <style>
+      body, html {
+        width:  100%;
+        height: 100%;
+        margin:  0;
+        padding: 0;
+      }
+      .geolonia {
+        width:  100%;
+        height: 100%;
+      }
+      .maplibregl-popup-content a:visited {
+	color: blue;
+      }
+      #mode-badge {
+        position:   fixed;
+        top:        8px;
+        left:       8px;
+        z-index:    1000;
+        background: rgba(0, 0, 0, 0.7);
+        color:      #fff;
+        font:       12px/1.4 sans-serif;
+        padding:    4px 8px;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="mode-badge">テストページ: default マーカー (circle)</div>
+    <div
+      class="geolonia"
+      data-geojson="./dojos.default.min.geojson"
+      data-lat="35.6809591"
+      data-lng="139.7673068"
+      data-zoom="5"
+      data-marker="off"
+      data-custom-marker="#custom-marker"
+      data-custom-marker-offset="0, 0"
+      data-geolocate-control="on"
+      data-cluster="off"
+      data-cluster-color="rgba(46, 154, 217, 0.8)"
+    ></div>
+
+    <script
+      type="text/javascript"
+      {% if site.env.GEOLONIA_API_KEY %}
+      src="https://cdn.geolonia.com/v1/embed?geolonia-api-key={{ site.env.GEOLONIA_API_KEY }}"
+      {% else %}
+      src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"
+      {% endif %}
+    ></script>
+  </body>
+</html>

--- a/test.html
+++ b/test.html
@@ -1,0 +1,66 @@
+---
+sitemap: false
+---
+
+<!-- マーカー方式のテスト用ハブ。/default.html と /coderdojo.html を横並びで
+     同時表示し、両方式を一目で見比べられる。Geolonia スプライト復旧後に
+     coderdojo 側にロゴが出れば PR #30（marker: coderdojo 切替）をマージ可。
+     関連: default.html / coderdojo.html / tests/markers_integrity_test.rb -->
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>[テスト] マーカー方式 - DojoMap</title>
+    <meta name="robots" content="noindex">
+    <link href="/images/icons/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+    <style>
+      body, html {
+        margin:  0;
+        padding: 0;
+        height:  100%;
+        font-family: sans-serif;
+      }
+      .panes {
+        display: flex;
+        height:  100%;
+      }
+      .pane {
+        flex:           1;
+        display:        flex;
+        flex-direction: column;
+        border-right:   1px solid #ccc;
+      }
+      .pane:last-child {
+        border-right: 0;
+      }
+      .pane h1 {
+        margin:     0;
+        padding:    8px 12px;
+        font-size:  14px;
+        background: #2e9ad9;
+        color:      #fff;
+      }
+      .pane h1 a {
+        color: #cdeafb;
+      }
+      .pane iframe {
+        flex:   1;
+        width:  100%;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panes">
+      <div class="pane">
+        <h1>default (circle・スプライト非依存) — <a href="/default.html" target="_blank" rel="noopener">全画面</a></h1>
+        <iframe src="/default.html" title="default マーカー"></iframe>
+      </div>
+      <div class="pane">
+        <h1>coderdojo (logo・スプライト依存) — <a href="/coderdojo.html" target="_blank" rel="noopener">全画面</a></h1>
+        <iframe src="/coderdojo.html" title="coderdojo マーカー"></iframe>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/markers_integrity_test.rb
+++ b/tests/markers_integrity_test.rb
@@ -126,3 +126,28 @@ class MarkerRenderingTest < Minitest::Test
                  'これは Geolonia スプライト サーバ依存となり、502 障害時にマーカーが全滅します。'
   end
 end
+
+# テストページ /default.html /coderdojo.html 用のモード別 GeoJSON バリアントを検証する。
+# これらは _config.yml の設定に依らず常に生成される（ビルド成果物なので gitignore 済み）。
+class MarkerVariantTest < Minitest::Test
+  # モード => そのモードで全フィーチャーが持つべきマーカー属性
+  VARIANT_MARKER_KEY = {
+    'default'   => 'marker-color',
+    'coderdojo' => 'marker-symbol',
+  }.freeze
+
+  def test_each_variant_geojson_has_correct_marker_property
+    VARIANT_MARKER_KEY.each do |mode, key|
+      path = File.join(ROOT, "dojos.#{mode}.geojson")
+      skip "dojos.#{mode}.geojson が未生成です（先に rake upsert_dojos_geojson を実行）" unless File.exist?(path)
+
+      features = JSON.parse(File.read(path))['features']
+      refute_empty features, "dojos.#{mode}.geojson の features が空です"
+
+      missing = features.reject { |f| f.dig('properties', key) }
+      assert_empty missing,
+                   "dojos.#{mode}.geojson の #{missing.size} 件が #{key} を持っていません。" \
+                   'テストページのマーカーが正しく描画されません。'
+    end
+  end
+end


### PR DESCRIPTION
## 目的

両マーカー方式を**本番サイト上でテスト/プレビュー**できるページを追加する。Geolonia スプライト サーバ復旧後に `coderdojo` ロゴ マーカーが実際に描画されるかを、**本番 `_config.yml` を変えずに**検証できる。

- **`/test.html`** ← テスト用ハブ。`default` と `coderdojo` を**横並びで同時表示**（1 URL で見比べ）
- `/default.html` → circle マーカー（`marker-color`・スプライト非依存）
- `/coderdojo.html` → CoderDojo ロゴ（`marker-symbol`・スプライト依存）

> 「テスト」が目的で、横並び比較はその手段。エントリポイントは `/test.html`。

## 仕組み

マーカーの見た目は HTML ではなく **GeoJSON データ側**（`marker-color` vs `marker-symbol`）で決まるため、各ページが対応するバリアント GeoJSON を読み込む。

- `_tasks/upsert_dojos_geojson.rb`: マーカー定義を `MARKER_PROPS` マップに集約し、**features を 1 回構築**して各モードの `dojos.#{mode}.geojson` を常に生成（本番 `dojos.geojson` は従来通り `_config.yml` の選択モード。プロパティ順序を保ち差分ゼロ）
- `_tasks/compact_geojson.rb`: `dojos*.geojson` を走査して各 `.min.geojson` を生成
- `default.html` / `coderdojo.html`: 本番 `index.html` と**同じ Geolonia 設定**で `data-geojson` のみ差し替え。モード バッジ + `/test.html` への相互リンク付き
- `test.html`: 上記 2 ページを `<iframe>` で横並び表示。各ペインに全画面リンク
- すべて `sitemap: false` + `robots: noindex`（検索除外・GA なし）
- `.gitignore`: 生成物 `dojos.default*` / `dojos.coderdojo*` を無視（ビルド時生成）
- `tests/markers_integrity_test.rb`: 各バリアントが正しいマーカー属性を持つか検証（`MarkerVariantTest`）

## 検証（ヘッドレス Chrome）

| ページ | 結果 |
|---|---|
| `/test.html` | ✅ 左=円マーカー描画 / 右=502 で空（横並び比較が機能） |
| `/default.html` | ✅ 全国に**円マーカー**描画 |
| `/coderdojo.html` | ⚠️ 現在 502 のため**マーカー無し**（=スプライト障害を再現。復旧後にロゴ表示の想定） |

`rake test`（html-proofer）も 5 ファイル（index/world/default/coderdojo/test）すべて通過。

## 使い方の流れ（PR 群の連携）

1. **本 PR**: テストページ追加 → マージ後、本番で https://map.coderdojo.jp/test.html を常時監視可能に
2. Geolonia 復旧 + `coderdojo` スプライト登録後、`/test.html` の右ペインにロゴが出るか確認
3. 確認できたら **PR #30**（`marker: coderdojo` 切替・Draft）をマージ

## 関連

- 円マーカー化（現状の本番）: #28
- ロゴ復帰の準備（Draft）: #30