### PR TITLE
暫定: 地図の既定ズームを 6 に（Geolonia 低ズームタイル障害の回避）

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,12 +61,16 @@
     </style>
   </head>
   <body>
+    <!-- NOTE(2026-07): 暫定ワークアラウンド。Geolonia のベクタタイル(v3)が
+         ズーム 0〜5 で 500 を返す障害中のため、既定ズームを 6 にして地図が
+         描画されるようにしている（z6 以上は 200）。Geolonia 復旧後は
+         data-zoom="5"（全国一望）に戻してよい。詳細な調査は別途。 -->
     <div
       class="geolonia"
       data-geojson="./dojos.min.geojson"
-      data-lat="35.6809591"
-      data-lng="139.7673068"
-      data-zoom="5"
+      data-lat="36.5"
+      data-lng="138.0"
+      data-zoom="6"
       data-marker="off"
       data-custom-marker="#custom-marker"
       data-custom-marker-offset="0, 0"


### PR DESCRIPTION
## 目的（ASAP 暫定対応）

本番の地図タイルが表示されない不具合の**即時ワークアラウンド**。既定ズームを 5→6 にして地図が描画されるようにする。

## 原因（再現済み）

Geolonia のベクタタイル `tileserver.geolonia.com/v3/tiles/{z}/{x}/{y}.mvt` が **ズーム 0〜5 で 500** を返している（`{"error":true}` / `x-cache: Error from cloudfront`＝先方のバックエンド障害）。**ズーム 6 以上は 200**。

| ズーム | .mvt |
|---|---|
| z0〜z5 | 🔴 500 |
| z6〜z14 | ✅ 200 |

- キー非依存: `map.coderdojo.jp`（DojoMap）でも `localmap.jp`（LocalMap）でも同じ
- `localmap.jp` が動くのは各ページが **z14**（局所ビュー）だから。`map.coderdojo.jp` は全国 **z5** のため低ズームの壊れたタイルを踏む

## 変更

`index.html`: `data-zoom="5" → "6"`、中心を中部日本(36.5, 138.0)に調整して z6 でより広く日本が見えるように。

## トレードオフ / 注意

- z6 は全国一望より狭い。**ユーザーがズームアウト(z5以下)すると再びタイルが 500**（Geolonia 側が直るまでの暫定）
- マーカー（CoderDojo ロゴ）は影響なし

## フォローアップ（別途調査・恒久対策）

- Geolonia に低ズームタイル 500 を報告
- 恒久策候補: **GSI ラスタタイルを使うカスタムスタイル**（全ズームで描画・Geolonia ベクタタイル非依存）を検証済み（z5 全国描画を確認済み）

## マージ後

`data-zoom="5"` に戻すのは Geolonia 復旧後。