### PR TITLE
chore: GitHub Actions を最新バージョンに更新

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy_to_pages.yml
+++ b/.github/workflows/deploy_to_pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 📥 Download codes from GitHub
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 2
 

--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: 📥 Download codes from GitHub
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 2
 
@@ -111,11 +111,11 @@ jobs:
     - name: 🔔 Notify error to Slack (if any)
       if:   failure()
       id:   slack
-      uses: slackapi/slack-github-action@v1.24.0
-      env:
-        SLACK_WEBHOOK_URL:  ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      uses: slackapi/slack-github-action@v3.0.5
       with:
+        webhook:      ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+
         # For posting a simple plain text message
         payload: |
           {


### PR DESCRIPTION
## 概要

ワークフローで使っている Actions を最新版に更新しました。

| Action | Before | After | 備考 |
|---|---|---|---|
| `actions/checkout` | v5 | **v7** | 3 ワークフローすべて |
| `slackapi/slack-github-action` | v1.24.0 | **v3.0.5** | 入力仕様に破壊的変更あり（下記） |
| `ruby/setup-ruby` | v1 | v1 | 浮動メジャータグ。実体は最新の v1.316.0 |
| `peaceiris/actions-gh-pages` | v4 | v4 | 浮動メジャータグ。実体は最新の v4.1.0 |

## 破壊的変更への対応

### actions/checkout v5 → v7

v7 の破壊的変更は「`pull_request_target` / `workflow_run` での fork PR のチェックアウトを禁止」ですが、当リポジトリの `claude-review.yml` は通常の `pull_request` トリガーを使っており、他の 2 つは `push` / `schedule` なので**影響ありません**。v6 での変更は Node.js 24 ランタイム化と認証情報の保存先変更で、GitHub ホストランナーでは対応済みです。

### slackapi/slack-github-action v1.24.0 → v3.0.5

v2 で incoming webhook の指定方法が変わったため、[公式の移行ガイド](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0)に沿って書き換えました。

- `SLACK_WEBHOOK_URL` 環境変数 → `webhook` 入力値
- `SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK` 環境変数 → `webhook-type: incoming-webhook` 入力値

`payload` の JSON はそのまま利用できるため、通知内容に変更はありません。v3 の破壊的変更は Node.js 24 ランタイム化のみで、GitHub ホストランナーでは対応済みです。

## 動作確認

- ✅ 4 つのワークフローすべて YAML パース成功
- ⚠️ Slack 通知ステップは `if: failure()` で、日次ビルドが失敗したときにしか発火しません。実際の送信は次にビルドが失敗したときまで検証できないため、意図的にビルドを壊さない限りこの PR では確認できない点にご留意ください（設定内容は公式移行ガイドどおりです）。