### PR TITLE
CoderDojo 大和西大寺・姫路・伊佐@本城・佐久のマッピングを追加

### DIFF
--- a/dojo2dojo.csv
+++ b/dojo2dojo.csv
@@ -283,12 +283,16 @@ Japan登録名	Zen登録名
 早良	早良
 	テクノ@光都
 	Himi @ Big Berries
-新大阪	CoderDojo新大阪
 鳥羽@竹田住設	鳥羽 @ 竹田住設
 南会津	CoderDojo南会津
 八女	CoderDojo八女
+新大阪	CoderDojo新大阪
 SAGA@駅前中央	CoderDojo SAGA@駅前中央
 西条	CoderDojo Saijo
 新居浜	CoderDojo愛媛新居浜
+大和西大寺	CoderDojo大和西大寺
+姫路	姫路 CoderDojo
+伊佐@本城	伊佐 @ 本城
+佐久	CoderDojo 佐久
 
 	


### PR DESCRIPTION
## 概要

`dojo2dojo.csv` に 4 件のマッピングを追加しました。これにより Japan API と Clubs API の重複エントリが統合され、それぞれ 1 件ずつ地図に表示されるようになります。

| Japan 登録名 | Zen (Clubs) 登録名 |
|---|---|
| 大和西大寺 | CoderDojo大和西大寺 |
| 姫路 | 姫路 CoderDojo |
| 伊佐@本城 | 伊佐 @ 本城 |
| 佐久 | CoderDojo 佐久 |

## 生成物をコミットしない理由

`_data/dojo2dojo.json` と `dojos.geojson` は**意図的にコミットしていません**。

- `deploy_to_pages.yml` が main への push で `jekyll build` を実行し、ビルドフックが CSV から GeoJSON を再生成してデプロイする
- `scheduler_daily.yml` が日次で生成物（`_data/*.json`, `dojos.geojson`）を main にコミットし直す

そのため CSV だけで公開される地図は正しく更新されます。あわせて、先日更新した GitHub Actions（`actions/checkout@v7` など）が実際に動くかの確認も兼ねています。

## ローカル検証

- ✅ 4 件とも Japan API / Clubs API の登録名と**完全一致**
- ✅ 再生成した `dojos.geojson` / `dojos.min.geojson` に**各 1 件（重複なし）** で反映
- ✅ 座標も妥当（奈良 135.78,34.69 / 姫路 134.69,34.83 / 鹿児島 130.63,31.99 / 佐久 138.47,36.22）
- ✅ ロゴ画像（`yamato-saidaiji.webp`, `himeji.webp`, `isa.webp`, `saku.webp`）とポップアップのリンクも正常
- ✅ `rake test_markers`: 6 runs / 0 failures