### PR TITLE
Slack 通知を手動でテストするワークフローを追加

### DIFF
--- a/.github/workflows/test_slack_notification.yml
+++ b/.github/workflows/test_slack_notification.yml
@@ -1,0 +1,40 @@
+name: Test Slack Notification
+
+# scheduler_daily.yml の Slack 通知ステップは `if: failure()` 条件のため、
+# 日次ビルドが失敗しない限り発火せず、動作確認ができない。
+# このワークフローは通知ステップだけを手動実行できるようにしたもの。
+# slackapi/slack-github-action をアップグレードした際の疎通確認に使う。
+#
+# 実行方法:
+#   gh workflow run test_slack_notification.yml
+#
+# 注意: scheduler_daily.yml の Slack ステップと同じ設定を保つこと。
+#       片方だけ変更すると、このテストの意味がなくなる。
+on:
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 🔔 Send a test message to Slack
+      uses: slackapi/slack-github-action@v3.0.5
+      with:
+        webhook:      ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+
+        # scheduler_daily.yml と同じ形式のペイロード（文面のみテスト用）
+        payload: |
+          {
+            "text": "[TEST] DojoMap の Slack 通知テストです。(詳細を見る)",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "[TEST] DojoMap の Slack 通知テストです。エラー通知ではありません。(<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|詳細を見る>)"
+                }
+              }
+            ]
+          }


### PR DESCRIPTION
## 課題

`scheduler_daily.yml` の Slack 通知ステップは `if: failure()` 条件のため、**日次ビルドが失敗しない限り発火せず、動作確認ができません**。先日 `slackapi/slack-github-action` を v1.24.0 → v3.0.5 に上げた際も（webhook の指定方法に破壊的変更があったにもかかわらず）未検証のままでした。

つまり「次にビルドが壊れたとき、通知が飛ばないことに初めて気づく」という状態です。通知の設定ミスは、一番通知が必要なタイミングで発覚するのが最悪です。

## 解決

通知ステップだけを `workflow_dispatch` で手動実行できる小さなワークフローを追加しました。

```
gh workflow run test_slack_notification.yml
```

- **副作用ゼロ**: データ取得もビルドもデプロイもせず、Slack にテストメッセージを 1 通送るだけ
- **再利用可能**: 今後 Slack Action をアップグレードするたびに疎通確認できる
- メッセージには `[TEST]` を付け、エラー通知と区別できるようにしています

### 代替案として検討したもの

`scheduler_daily.yml` に `workflow_dispatch` のテスト入力を足す案もありましたが、通知を試すたびに日次ジョブ全体（API 取得・ビルド・main へのコミット・GitHub Pages デプロイ）が走ってしまい副作用が大きいため、独立したワークフローにしました。

## 注意点

`scheduler_daily.yml` の Slack ステップと**同じ設定を保つ必要があります**（片方だけ変更するとテストの意味がなくなる）。その旨をワークフローのコメントに明記しました。

## 確認方法

`workflow_dispatch` は default branch にファイルがないと実行できないため、**マージ後**に上記コマンドで実行し、Slack にメッセージが届くことを確認します。