### PR TITLE
Slack 通知のリンク文言を » 詳細を見る (GitHub) に変更

### DIFF
--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -119,13 +119,13 @@ jobs:
         # For posting a simple plain text message
         payload: |
           {
-            "text": "<@yasulab> Failed to build DojoMap. (詳細を見る)",
+            "text": "<@yasulab> Failed to build DojoMap. » 詳細を見る (GitHub)",
             "blocks": [
               {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "<@yasulab> Failed to build DojoMap. (<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|詳細を見る>)"
+                  "text": "<@yasulab> Failed to build DojoMap. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|» 詳細を見る (GitHub)>"
                 }
               }
             ]

--- a/.github/workflows/test_slack_notification.yml
+++ b/.github/workflows/test_slack_notification.yml
@@ -27,13 +27,13 @@ jobs:
         # scheduler_daily.yml と同じ形式のペイロード（文面のみテスト用）
         payload: |
           {
-            "text": "`[TEST]` DojoMap の Slack 通知テストです。(詳細を見る)",
+            "text": "`[TEST]` DojoMap の Slack 通知テストです。» 詳細を見る (GitHub)",
             "blocks": [
               {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "`[TEST]` DojoMap の Slack 通知テストです。(<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|詳細を見る>)"
+                  "text": "`[TEST]` DojoMap の Slack 通知テストです。<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|» 詳細を見る (GitHub)>"
                 }
               }
             ]


### PR DESCRIPTION
## 概要

Slack 通知内のリンク文言を `(詳細を見る)` から `» 詳細を見る (GitHub)` に変更しました。

- `»` と `(GitHub)` をリンクテキストの内側に含めたので、一連の文字列がまとめてリンクとして表示され、遷移先が GitHub であることが一目で伝わります
- Slack の mrkdwn は HTML エンティティ（`&raquo;`）を展開しないため、リテラルの `»` 文字を使用しています
- `test_slack_notification.yml` と `scheduler_daily.yml` の両方を同じ文面に揃えています

## 動作確認

`gh workflow run test_slack_notification.yml --ref decorate-slack-detail-link` でテスト通知を送信し、Slack 上での表示を確認済みです。