### PR TITLE
bundler の警告を解消（BUNDLED WITH を 4.0.10 に更新）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,4 +208,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.6.9
+   4.0.10


### PR DESCRIPTION
## 症状

`bundle exec` を実行するたびに、警告が **18 行**出ていた。

```
/Users/.../bundler-2.6.9/lib/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/.../rubygems/platform.rb:279: warning: previous definition of JAVA was here
（MSWIN / MSWIN64 / MINGW / X64_MINGW / UNIVERSAL_MINGW / WINDOWS / X64_LINUX / X64_LINUX_MUSL と続く）
```

## 原因

**Ruby 4.0.5 は bundler 4.0.10 を同梱している**のに、`Gemfile.lock` の `BUNDLED WITH` が **2.6.9** のままだったため、古い bundler が起動していた。

古い bundler の `rubygems_ext.rb` が、Ruby 4.0 の rubygems が既に定義済みの `Gem::Platform` 定数を再定義するため、警告が出ていた。

Ruby を 3.4.4 → 4.0.5 に上げた PR #33 の積み残し。

## 対応

`Gemfile.lock` の `BUNDLED WITH` を **4.0.10**（Ruby 4.0.5 同梱版）に更新。

## 実測（原因を確定させるため、修正前後を比較）

| 状態 | warning の行数 |
|---|---|
| 修正前（`BUNDLED WITH 2.6.9`） | **18 行** |
| 修正後（`BUNDLED WITH 4.0.10`） | **0 行** |

- ✅ `bundle exec jekyll build` : warning 0 行
- ✅ `bundle exec rake test_markers` : 6 runs / 0 failures
- ✅ `bundle -v` が 4.0.10 を返すことを確認