### PR TITLE
地図の依存サービスの応答を毎日確認し、異常時に Slack へ通知する

### DIFF
--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -108,6 +108,57 @@ jobs:
         personal_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir:    ./_site
 
+    # 地図の表示は Geolonia のサービスに依存している。過去2回、サイト自体は HTTP 200 を
+    # 返しているのに地図が表示されない状態が発生した。自サイトの死活監視では気づけないため、
+    # 依存先の応答を毎日確認する。
+    #   2026/06: スプライト サーバが 502 → マーカーが1件も描画されなかった
+    #   2026/07: 埋め込み v1 が参照する旧インフラの不具合 → 世界地図が描画されなかった
+    #
+    # 意図的な設計:
+    # - デプロイの「後」に置く。依存先に異常がある時こそ marker: default への切替を
+    #   デプロイしたいので、外部要因でデプロイを止めてはならない
+    # - continue-on-error でジョブ自体は失敗させない（本体のビルド失敗と混同しないため）
+    # - always() でビルドが失敗した時も実行する（依存先の状態は常に知りたい）
+    - name: 🩺 Check map dependencies
+      id:   geolonia
+      if:   always()
+      continue-on-error: true
+      run: |
+        set -e
+
+        # 1. 埋め込みスクリプト (_config.yml で一元管理している URL を読む)
+        EMBED_URL=$(ruby -ryaml -e 'puts YAML.load_file("_config.yml")["geolonia_embed_url"]')
+        echo "Checking embed script: $EMBED_URL"
+        curl -sfL --retry 3 --retry-delay 30 --max-time 30 \
+             "$EMBED_URL?geolonia-api-key=YOUR-API-KEY" -o /tmp/embed.js
+        test -s /tmp/embed.js  # 空でないこと（200 を返しても中身が空なら異常）
+
+        # 2. スプライト サーバ (マーカー描画に必須)
+        echo "Checking sprite server..."
+        ruby tests/sprite_status_test.rb   # 標準ライブラリのみ。bundle install 不要
+      env:
+        GEOLONIA_API_KEY: ${{ secrets.GEOLONIA_API_KEY }}
+
+    - name: 🔔 Notify map dependency issue to Slack (if any)
+      if:   always() && steps.geolonia.outcome == 'failure'
+      uses: slackapi/slack-github-action@v3.0.5
+      with:
+        webhook:      ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": "<@yasulab> 地図の依存サービスから正常な応答が得られていません。地図が表示されない可能性があります。",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<@yasulab> *地図の依存サービス (Geolonia) から正常な応答が得られていません。* 地図が表示されない可能性があります。\n\n*暫定復旧の手順:* マーカーが表示されない場合、`_config.yml` の `marker: coderdojo` を `marker: default` に変更して再デプロイすると、スプライト サーバに依存しない circle マーカーに切り替わります。\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|» 詳細を見る (GitHub)>"
+                }
+              }
+            ]
+          }
+
     - name: 🔔 Notify error to Slack (if any)
       if:   failure()
       id:   slack

--- a/tests/sprite_status_test.rb
+++ b/tests/sprite_status_test.rb
@@ -1,63 +1,85 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Geolonia スプライト サーバの健全性を手動で確認するためのテスト。
+# Geolonia スプライト サーバの健全性を確認するテスト。
 #
 # 関連 PR: https://github.com/coderdojo-japan/map.coderdojo.jp/pull/28
 #
 # == 用途 ==
-# マーカーは Geolonia のスプライト サーバ
-# (https://api.geolonia.com/v1/sprites/...) からアイコン画像を取得して描画する。
-# このサーバが 502 等で落ちると marker-symbol ベースのマーカーが全滅する
-# （2026/06 の不具合の真因）。本テストはその状態を手動で検査する。
+# マーカーは Geolonia のスプライト サーバからアイコン画像を取得して描画する。
+# このサーバから正常な応答が得られないと marker-symbol ベースのマーカーが描画されない
+# （2026/06 の不具合の原因）。本テストはその状態を検査する。
 #
-# == CI には統合しない ==
-# 外部サービスの瞬間的な状態に CI/デプロイを依存させない（赤くしない）ため、
-# `rake test` には含めない。必要なときに手動で実行する:
-#   GEOLONIA_API_KEY=xxxx bundle exec rake test_sprite
-#   (または GEOLONIA_API_KEY=xxxx ruby tests/sprite_status_test.rb)
+# == 実行方法 ==
+# scheduler_daily.yml から毎日実行され、失敗すると Slack に通知される。
+# 手動実行する場合:
+#   GEOLONIA_API_KEY=xxxx ruby tests/sprite_status_test.rb
+#
+# == デプロイは止めない ==
+# 外部サービスの状態でデプロイを止めてはならない（依存先に異常がある時こそ
+# marker: default への切替をデプロイしたい）。そのため `rake test` には含めず、
+# ワークフロー側で continue-on-error として実行する。
 #
 # == セキュリティ ==
 # Geolonia の埋め込みキーはクライアント用の公開キー（公開サイトの HTML に既に
 # 埋め込み済み）。ドメイン制限で保護される種類。とはいえ本テストは URL や
-# キーをログに出さず、HTTP ステータスと coderdojo の有無だけを出力する。
+# キーをログに出さず、HTTP ステータスだけを出力する。
 
 require 'minitest/autorun'
 require 'json'
 require 'net/http'
 require 'uri'
 
-SPRITE_BASE = 'https://api.geolonia.com/v1/sprites/basic-v1@2x'
+# 埋め込み v5 が使うスタイル (basic-v2) のスプライト。
+# 2026/07 時点で api.geolonia.com は cdn.geolonia.com へ 302 リダイレクトするため、
+# リダイレクトを追う必要がある（追わないと 302 を異常と誤検知し、毎日誤報が飛ぶ）。
+SPRITE_URL = 'https://api.geolonia.com/v1/sprites/basic-v2.json'
 
 class SpriteStatusTest < Minitest::Test
   def setup
     @key = ENV['GEOLONIA_API_KEY'].to_s
-    skip 'GEOLONIA_API_KEY が未設定です（手動実行時に環境変数で渡してください）' if @key.empty?
+    skip 'GEOLONIA_API_KEY が未設定です' if @key.empty?
 
-    uri = URI("#{SPRITE_BASE}.json?key=#{@key}")
-    @response = Net::HTTP.get_response(uri)
+    @response = fetch_following_redirects(URI("#{SPRITE_URL}?key=#{@key}"))
   rescue StandardError => e
     @error = e
   end
 
-  # スプライト JSON が正常(200)に返るか
+  # スプライト サーバから正常な応答が得られるか。
+  # 応答が得られないと marker-symbol ベースのマーカーが描画されない。
   def test_sprite_endpoint_is_healthy
     flunk "スプライト取得で通信エラー: #{@error.class}: #{@error.message}" if @error
 
     assert_equal '200', @response.code,
-                 "Geolonia スプライト サーバが正常応答していません (HTTP #{@response.code})。" \
-                 'marker-symbol ベースのマーカーは描画されません。' \
-                 '_config.yml は marker: default（スプライト非依存）を推奨します。'
+                 "スプライト サーバから正常な応答が得られていません (HTTP #{@response.code})。" \
+                 'マーカーが描画されない可能性があります。' \
+                 '暫定復旧: _config.yml の marker: coderdojo を marker: default に変更して' \
+                 '再デプロイすると、スプライト非依存の circle マーカーに切り替わります。'
   end
 
-  # スプライトに 'coderdojo' シンボルが含まれるか（coderdojo モードが使えるか）
-  def test_sprite_contains_coderdojo_symbol
+  # 200 を返しても中身が壊れていることはある（今日の教訓: ステータスではなく中身を見る）。
+  def test_sprite_json_is_parsable
     flunk "スプライト取得で通信エラー: #{@error.class}: #{@error.message}" if @error
     skip "スプライトが 200 を返していません (HTTP #{@response.code})" unless @response.code == '200'
 
     symbols = JSON.parse(@response.body)
-    assert symbols.key?('coderdojo'),
-           "スプライトに 'coderdojo' シンボルがありません（含まれるシンボル数: #{symbols.size}）。" \
-           'marker: coderdojo に切り替えてもロゴ マーカーは描画されません。'
+    refute_empty symbols, 'スプライト JSON が空です。マーカーが描画されない可能性があります。'
+  end
+
+  # NOTE: 以前ここに「スプライトに coderdojo シンボルが含まれるか」を検査するテストがあったが、
+  # 2026/07 に削除した。実測したところ basic-v1 / basic-v2 のいずれにも（API キーの有無に
+  # かかわらず）coderdojo シンボルは存在しないが、マーカーは正常に CoderDojo ロゴで描画されて
+  # いた（スクリーンショットで確認済み）。前提が現実と食い違っており、残すと毎日誤報が飛ぶ。
+  # ロゴがどの経路で読み込まれているかは未解明。判明したら適切な監視を足すこと。
+
+  private
+
+  def fetch_following_redirects(uri, limit = 3)
+    raise 'リダイレクトが多すぎます' if limit.zero?
+
+    res = Net::HTTP.get_response(uri)
+    return res unless res.is_a?(Net::HTTPRedirection)
+
+    fetch_following_redirects(URI(res['location']), limit - 1)
   end
 end


### PR DESCRIPTION
## 課題

過去 2 回、**サイト自体は HTTP 200 を返しているのに地図が表示されない**状態が発生し、気づくのが遅れた。自サイトの死活監視では検知できないため、地図の表示に必要な依存先の応答を毎日確認する。

| 時期 | 状況 | 症状 |
|---|---|---|
| 2026/06 | スプライト サーバが 502 | マーカーが 1 件も描画されなかった |
| 2026/07 | 埋め込み v1 が参照する旧インフラの不具合 | 世界地図が描画されなかった |

## 設計：依存先の HTTP 応答を確認する

**ヘッドレス Chrome での描画検証は採用しない。** 一見理想的だが、実験の結果**世界地図（zoom 0）はヘッドレスでは描画が完了しない**（v1 / v5 とも同じ）。つまり 2026/07 型の状態を**そもそも検知できない**。検知したい対象を検知できない手段に投資する意味はない。加えて SwiftShader 描画は遅く不安定で、偽陽性がアラートの信頼を損なう。

過去 2 件は**どちらも HTTP 層で検知できる**ので、依存先の応答を直接確認する。

1. 埋め込みスクリプト（`_config.yml` の `geolonia_embed_url` から読む）→ 200 かつ**中身が空でないこと**
2. スプライト サーバ（`tests/sprite_status_test.rb`。標準ライブラリのみなので `bundle install` 不要）

**独立ワークフローは作らず `scheduler_daily.yml` に相乗りする**（YAGNI）。1 日 1 回でも現状からは大きな改善で、分離は実際に必要になってからでよい。

## 2 つのガードレール

**① 外部要因でデプロイを止めない。** デプロイの**後**に置き、`continue-on-error` でジョブを失敗させない。依存先に異常がある時こそ `marker: default` への切替をデプロイしたいので、外部要因でデプロイが止まったら本末転倒。

**② アラートで原因の切り分けができるようにする。** 既存の通知は「Failed to build DojoMap」だけで、自分のビルド失敗と依存先の異常を区別できない。監視専用の通知を用意し、**本文に復旧手順を明記**した。

> *暫定復旧の手順:* マーカーが表示されない場合、`_config.yml` の `marker: coderdojo` を `marker: default` に変更して再デプロイすると、スプライト サーバに依存しない circle マーカーに切り替わります。

## `sprite_status_test.rb` の修正（誤報を出す状態だった）

このテストは「作ったが CI に入っていない」状態で放置されており、**実行してみたら失敗した**。そのまま監視に載せていたら**毎日誤報**が飛んでいた。

- **リダイレクトを追っていなかった**。`api.geolonia.com` は `cdn.geolonia.com` へ 302 を返すが、テストはそれを異常と判定していた
- **検査対象が古かった**。埋め込み v5 が使うのは `basic-v2` だが、テストは `basic-v1` を見ていた
- **「スプライトに `coderdojo` シンボルが含まれるか」の検査を削除した**。実測したところ `basic-v1` / `basic-v2` のいずれにも（API キーの有無にかかわらず）`coderdojo` は**存在しない**が、マーカーは正常に CoderDojo ロゴで描画されている（スクリーンショットで確認済み）。**前提が現実と食い違っており、残すと毎日誤報が飛ぶ**

**未解明**: ロゴがどの経路で読み込まれているかは特定できなかった。推測で埋めず、コード内に NOTE として残した。判明したら適切な監視を足す。

## 検証

- ✅ 埋め込みスクリプトのチェックをローカルで実行（200 / 1,235,244 bytes）
- ✅ スプライト テストが正常時に通る（2 runs / 0 failures / 0 skips）
- ✅ **異常を模擬すると復旧手順つきのメッセージで正しく失敗する**（RED → GREEN）
- ✅ YAML パース成功